### PR TITLE
[FEAT] event 삭제 , 수정 , 조회 , 숨김 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ dependencies {
     // Springdoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.12'
     implementation 'org.apache.commons:commons-lang3:3.18.0'
+
+    //test
+    testImplementation 'com.h2database:h2'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.example.skillup.domain.event.controller;
 
 import com.example.skillup.domain.event.dto.request.EventRequest;
+import com.example.skillup.domain.event.dto.response.EventResponse;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.enums.EventStatus;
 import com.example.skillup.domain.event.service.EventService;
@@ -13,7 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,26 +29,64 @@ public class EventController {
     @Operation(summary = "행사 등록 API", description = "관리자가 행사를 등록합니다.")
     @ApiResponse(responseCode = "200", description = "행사 등록 성공",
             content = @Content(mediaType = "application/json"))
-    public BaseResponse<String> createEvent(
-            @RequestBody @Valid EventRequest.CreateEvent request,
-            @AuthenticationPrincipal User user
+    public BaseResponse<EventResponse.CommonEventResponse> createEvent(
+            @RequestBody @Valid EventRequest.CreateEvent request
     ) {
-        //Event event = eventService.createEvent(userDetails.getUsers(),request);
         Event event = eventService.createEvent(request);
         String message = event.getStatus() == EventStatus.DRAFT ? "행사가 임지저장 되었습니다." : "행사가 등록되었습니다. ";
-        return BaseResponse.success(message ,"EVENT_ID : " + event.getId());
+        return BaseResponse.success(message ,new EventResponse.CommonEventResponse(event.getId()));
     }
+
+    @PutMapping("/{eventId}")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "행사 수정 API", description = "관리자가 특정 행사를 수정합니다.")
+    public BaseResponse<EventResponse.CommonEventResponse> updateEvent(
+            @PathVariable Long eventId,
+            @RequestBody @Valid EventRequest.UpdateEvent request
+    ) {
+
+        return BaseResponse.success("행사가 수정되었습니다.", eventService.updateEvent(eventId,request));
+    }
+
+    @PatchMapping("/{eventId}/hide")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "행사 숨김 API", description = "관리자가 특정 행사를 숨김 처리합니다.")
+    public BaseResponse<EventResponse.CommonEventResponse> hideEvent(
+            @PathVariable Long eventId
+    ) {
+
+        return BaseResponse.success("행사가 숨김 처리되었습니다.", eventService.hideEvent(eventId));
+    }
+
+    @PatchMapping("/{eventId}/publish")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "행사 공개 API" , description = "관리자가 특정 행사를 공개 처리합니다.")
+    public BaseResponse<EventResponse.CommonEventResponse> publishEvent(
+            @PathVariable Long eventId
+    ) {
+
+        return BaseResponse.success("행사가 공개되었습니다.", eventService.publishEvent(eventId));
+    }
+
 
     @DeleteMapping("/{eventId}")
     @PreAuthorize("hasRole('OWNER')")
     @Operation(summary = "행사 삭제 API", description = "관리자가 특정 행사를 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "행사 삭제 성공",
             content = @Content(mediaType = "application/json"))
-    public BaseResponse<String> deleteEvent(
-            @PathVariable Long eventId,
-            @AuthenticationPrincipal User user
+    public BaseResponse<EventResponse.CommonEventResponse> deleteEvent(
+            @PathVariable Long eventId
     ) {
-        eventService.deleteEvent(eventId);
-        return BaseResponse.success("행사가 삭제되었습니다" ,"EVENT_ID : " + eventId);
+        return BaseResponse.success("행사가 삭제되었습니다" , eventService.deleteEvent(eventId));
+    }
+
+    @GetMapping("/{eventId}")
+    @Operation(summary = "행사 상세 조회 API", description = "특정 행사의 상세 정보를 불러옵니다.")
+    public BaseResponse<EventResponse.EventSelectResponse> getEventDetail(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal UserDetails user
+    ) {
+        EventResponse.EventSelectResponse response = eventService.getEventDetail(eventId , user.getAuthorities());
+        return BaseResponse.success("행사 상세 조회 성공", response);
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -33,7 +33,7 @@ public class EventController {
             @RequestBody @Valid EventRequest.CreateEvent request
     ) {
         Event event = eventService.createEvent(request);
-        String message = event.getStatus() == EventStatus.DRAFT ? "행사가 임지저장 되었습니다." : "행사가 등록되었습니다. ";
+        String message = event.getStatus() == EventStatus.DRAFT ? "행사가 임시저장 되었습니다." : "행사가 등록되었습니다.";
         return BaseResponse.success(message ,new EventResponse.CommonEventResponse(event.getId()));
     }
 
@@ -77,7 +77,7 @@ public class EventController {
     public BaseResponse<EventResponse.CommonEventResponse> deleteEvent(
             @PathVariable Long eventId
     ) {
-        return BaseResponse.success("행사가 삭제되었습니다" , eventService.deleteEvent(eventId));
+        return BaseResponse.success("행사가 삭제되었습니다." , eventService.deleteEvent(eventId));
     }
 
     @GetMapping("/{eventId}")

--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -1,6 +1,7 @@
 package com.example.skillup.domain.event.dto.request;
 
 import com.example.skillup.domain.event.enums.EventCategory;
+import com.example.skillup.domain.event.enums.EventStatus;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,55 @@ public class EventRequest {
     @AllArgsConstructor
     public static class CreateEvent {
 
+        @NotNull(message = "제목을 입력해주세요.")
+        private String title;
+
+        @NotNull(message = "썸네일 URL을 입력해주세요.")
+        private String thumbnailUrl;
+
+        @NotNull(message = "카테고리를 선택해주세요.")
+        private EventCategory category;
+
+
+        @NotNull(message = "행사 시작일을 입력해주세요.")
+        private LocalDateTime eventStart;
+        private LocalDateTime eventEnd;
+
+
+        @NotNull(message = "모집 시작일을 입력해주세요.")
+        private LocalDateTime recruitStart;
+        private LocalDateTime recruitEnd;
+
+
+        @NotNull(message = "참가비 정보를 입력해주세요.")
+        private Boolean isFree;
+        private Integer price;
+
+        @NotNull(message = "추천 대상 최소 1개 선택해주세요.")
+        @Size(min = 1, message = "최소 1개의 추천 대상이 필요합니다.")
+        private List<String> targetRoles;
+
+        @NotNull(message = "임시저장인지 등록인지 값을 보내주세요")
+        private boolean draft; // true 임시저장, false 최종등록
+
+        private Boolean isOnline;
+
+        private String locationText;
+        private String locationLink;
+
+        private String applyLink;
+
+        private String contact;
+
+        private String description;
+
+        private String hashtags;
+    }
+
+    @Getter
+    @AllArgsConstructor
+
+    public static class UpdateEvent {
         @NotNull(message = "제목을 입력해주세요.")
         private String title;
 

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -1,0 +1,54 @@
+package com.example.skillup.domain.event.dto.response;
+
+import com.example.skillup.domain.event.enums.EventCategory;
+import com.example.skillup.domain.event.enums.EventStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public class EventResponse {
+
+    @Getter
+    @AllArgsConstructor
+    public static class CommonEventResponse {
+        private Long eventId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class EventSelectResponse {
+        private Long id;
+        private String title;
+        private String thumbnailUrl;
+        private EventCategory category;
+
+        private LocalDateTime eventStart;
+        private LocalDateTime eventEnd;
+
+        private LocalDateTime recruitStart;
+        private LocalDateTime recruitEnd;
+
+        private Boolean isFree;
+        private Integer price;
+
+        private Boolean isOnline;
+        private String locationText;
+        private String locationLink;
+
+        private String applyLink;
+
+        private EventStatus status;
+
+        private String contact;
+
+        private String description;
+
+        private String hashtags;
+
+        private Set<String> targetRoles;
+    }
+}

--- a/src/main/java/com/example/skillup/domain/event/entity/Event.java
+++ b/src/main/java/com/example/skillup/domain/event/entity/Event.java
@@ -3,9 +3,6 @@ package com.example.skillup.domain.event.entity;
 import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventStatus;
-import com.example.skillup.domain.event.exception.EventException;
-import com.example.skillup.domain.event.exception.TargetRoleErrorCode;
-import com.example.skillup.domain.event.repository.TargetRoleRepository;
 import com.example.skillup.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,7 +10,6 @@ import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static lombok.AccessLevel.PROTECTED;
@@ -99,18 +95,8 @@ public class Event extends BaseEntity {
         role.getEvents().remove(this);
     }
 
-    public void updateTargetRoles(List<String> roleNames, TargetRoleRepository targetRoleRepository) {
-        this.targetRoles.forEach(role -> role.getEvents().remove(this));
-        this.targetRoles.clear();
 
-        roleNames.stream().distinct().forEach(name -> {
-            TargetRole role = targetRoleRepository.findByName(name)
-                    .orElseThrow(() -> new EventException(TargetRoleErrorCode.TARGET_ROLE_NOT_FOUND, name + "에"));
-            this.addTargetRole(role);
-        });
-    }
-
-    public void update(EventRequest.UpdateEvent request , TargetRoleRepository targetRoleRepository) {
+    public void update(EventRequest.UpdateEvent request) {
         this.title = request.getTitle();
         this.thumbnailUrl = request.getThumbnailUrl();
         this.category = request.getCategory();
@@ -128,9 +114,5 @@ public class Event extends BaseEntity {
         this.contact = request.getContact();
         this.description = request.getDescription();
         this.hashtags = request.getHashtags();
-
-        if (request.getTargetRoles() != null && !request.getTargetRoles().isEmpty()) {
-            updateTargetRoles(request.getTargetRoles(), targetRoleRepository);
-        }
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/enums/EventStatus.java
+++ b/src/main/java/com/example/skillup/domain/event/enums/EventStatus.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum EventStatus {
     DRAFT("임시저장"),
-    PUBLISHED("등록");
+    PUBLISHED("등록"),
+    HIDDEN("숨김");
 
     private final String toKorean;
 }

--- a/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum EventErrorCode implements ResultCode {
     EVENT_ENTITY_NOT_FOUND("EVENT_ENTITY_NOT_FOUND","행사가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    EVENT_ALREADY_HIDDEN("EVENT_ALREADY_HIDDEN", "이미 숨김된 행사입니다.", HttpStatus.BAD_REQUEST),
+    EVENT_ALREADY_PUBLISHED("EVENT_ALREADY_PUBLISHED","이미 등록된 행사입니다." ,HttpStatus.BAD_REQUEST),
     EVENT_ALREADY_DELETED("EVENT_ALREADY_DELETED", "이미 삭제된 행사입니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -1,9 +1,13 @@
 package com.example.skillup.domain.event.mapper;
 
 import com.example.skillup.domain.event.dto.request.EventRequest;
+import com.example.skillup.domain.event.dto.response.EventResponse;
 import com.example.skillup.domain.event.entity.Event;
+import com.example.skillup.domain.event.entity.TargetRole;
 import com.example.skillup.domain.event.enums.EventStatus;
 import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
 
 @Component
 public class EventMapper {
@@ -28,6 +32,33 @@ public class EventMapper {
                 .description(request.getDescription())
                 .hashtags(request.getHashtags())
                 .status(request.isDraft() ? EventStatus.DRAFT : EventStatus.PUBLISHED)
+                .build();
+    }
+
+    public EventResponse.EventSelectResponse toEventDetailInfo(Event event) {
+        return EventResponse.EventSelectResponse.builder()
+                .id(event.getId())
+                .title(event.getTitle())
+                .thumbnailUrl(event.getThumbnailUrl())
+                .category(event.getCategory())
+                .eventStart(event.getEventStart())
+                .eventEnd(event.getEventEnd())
+                .recruitStart(event.getRecruitStart())
+                .recruitEnd(event.getRecruitEnd())
+                .isFree(event.getIsFree())
+                .price(event.getPrice())
+                .isOnline(event.getIsOnline())
+                .locationText(event.getLocationText())
+                .locationLink(event.getLocationLink())
+                .applyLink(event.getApplyLink())
+                .status(event.getStatus())
+                .contact(event.getContact())
+                .description(event.getDescription())
+                .hashtags(event.getHashtags())
+                .targetRoles(event.getTargetRoles()
+                        .stream()
+                        .map(TargetRole::getName)
+                        .collect(Collectors.toSet()))
                 .build();
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
@@ -1,7 +1,12 @@
 package com.example.skillup.domain.event.repository;
 
 import com.example.skillup.domain.event.entity.Event;
+import com.example.skillup.domain.event.exception.EventErrorCode;
+import com.example.skillup.domain.event.exception.EventException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
+    default Event getEvent(Long eventId) {
+        return findById(eventId).orElseThrow(() -> new EventException(EventErrorCode.EVENT_ENTITY_NOT_FOUND,  "EventID 가 " + eventId + "인"));
+    }
 }

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -82,6 +82,7 @@ public class EventService {
             throw new EventException(EventErrorCode.EVENT_ALREADY_PUBLISHED ,"EventID가 " + eventId + "는");
         }
 
+        event.setStatus(EventStatus.PUBLISHED);
         return new EventResponse.CommonEventResponse(event.getId());
     }
 

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -57,7 +57,19 @@ public class EventService {
     public EventResponse.CommonEventResponse updateEvent(Long eventId, EventRequest.UpdateEvent request) {
         Event event = eventRepository.getEvent(eventId);
 
-        event.update(request , targetRoleRepository);
+        event.update(request);
+
+        if (request.getTargetRoles() != null && !request.getTargetRoles().isEmpty()) {
+            event.getTargetRoles().forEach(role -> role.getEvents().remove(event));
+            event.getTargetRoles().clear();
+
+            request.getTargetRoles().stream().distinct().forEach(name -> {
+                TargetRole role = targetRoleRepository.findByName(name)
+                        .orElseThrow(() -> new EventException(TargetRoleErrorCode.TARGET_ROLE_NOT_FOUND, name + "에"));
+                event.addTargetRole(role);
+            });
+        }
+
         return new EventResponse.CommonEventResponse(event.getId());
     }
 

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -43,7 +43,7 @@ public class EventService {
 
     @Transactional
     public EventResponse.CommonEventResponse deleteEvent(Long eventId) {
-        Event event = getEvent(eventId);
+        Event event = eventRepository.getEvent(eventId);
 
         if (event.getDeletedAt() != null) {
             throw new EventException(EventErrorCode.EVENT_ALREADY_DELETED, "EventID가 " + eventId + "는");
@@ -55,7 +55,7 @@ public class EventService {
 
     @Transactional
     public EventResponse.CommonEventResponse updateEvent(Long eventId, EventRequest.UpdateEvent request) {
-        Event event = getEvent(eventId);
+        Event event = eventRepository.getEvent(eventId);
 
         event.update(request , targetRoleRepository);
         return new EventResponse.CommonEventResponse(event.getId());
@@ -64,7 +64,7 @@ public class EventService {
 
     @Transactional
     public EventResponse.CommonEventResponse hideEvent(Long eventId) {
-        Event event = getEvent(eventId);
+        Event event = eventRepository.getEvent(eventId);
 
         if (event.getStatus() == EventStatus.HIDDEN) {
             throw new EventException(EventErrorCode.EVENT_ALREADY_HIDDEN, "EventID가 " + eventId + "는");
@@ -77,7 +77,7 @@ public class EventService {
 
     @Transactional
     public EventResponse.CommonEventResponse publishEvent(Long eventId) {
-        Event event = getEvent(eventId);
+        Event event = eventRepository.getEvent(eventId);
         if (event.getStatus() == EventStatus.PUBLISHED) {
             throw new EventException(EventErrorCode.EVENT_ALREADY_PUBLISHED ,"EventID가 " + eventId + "는");
         }
@@ -88,7 +88,7 @@ public class EventService {
 
     @Transactional(readOnly = true)
     public EventResponse.EventSelectResponse getEventDetail(Long eventId, Collection<? extends GrantedAuthority> authorities) {
-        Event event = getEvent(eventId);
+        Event event = eventRepository.getEvent(eventId);
 
         boolean isAdmin = authorities.stream()
                 .anyMatch(a -> a.getAuthority().equals("ROLE_OWNER"));
@@ -99,11 +99,6 @@ public class EventService {
         }
 
         return eventMapper.toEventDetailInfo(event);
-    }
-
-    private Event getEvent(Long eventId) {
-        return eventRepository.findById(eventId)
-                .orElseThrow(() -> new EventException(EventErrorCode.EVENT_ENTITY_NOT_FOUND,  "EventID 가 " + eventId + "인"));
     }
 
 

--- a/src/main/java/com/example/skillup/domain/user/entity/Users.java
+++ b/src/main/java/com/example/skillup/domain/user/entity/Users.java
@@ -1,11 +1,13 @@
 package com.example.skillup.domain.user.entity;
 
 import com.example.skillup.domain.user.enums.UserStatus;
+import com.example.skillup.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
@@ -16,7 +18,8 @@ import static lombok.AccessLevel.PROTECTED;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
-public class Users
+@SQLRestriction("deleted_at IS NULL")
+public class Users extends BaseEntity
 {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,16 +1,17 @@
 spring:
-  config:
-    import: optional:file:.env[.properties]
   datasource:
-    url: ${DATASOURCE_URL}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_UPPER=false
+    driver-class-name: org.h2.Driver
+    username: test
+    password:
   jpa:
-    database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: create-drop
+    show-sql: true
     properties:
       hibernate:
-        show_sql: true
         format_sql: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/src/test/java/com/example/skillup/domain/event/EventServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/EventServiceTest.java
@@ -1,4 +1,0 @@
-package com.example.skillup.domain.event;
-
-public class EventServiceTest {
-}

--- a/src/test/java/com/example/skillup/domain/event/EventServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/EventServiceTest.java
@@ -1,0 +1,4 @@
+package com.example.skillup.domain.event;
+
+public class EventServiceTest {
+}

--- a/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
@@ -1,0 +1,238 @@
+package com.example.skillup.domain.event.service;
+
+
+import com.example.skillup.domain.event.dto.request.EventRequest;
+import com.example.skillup.domain.event.entity.Event;
+import com.example.skillup.domain.event.entity.TargetRole;
+import com.example.skillup.domain.event.enums.EventCategory;
+import com.example.skillup.domain.event.enums.EventStatus;
+import com.example.skillup.domain.event.repository.EventRepository;
+import com.example.skillup.domain.event.repository.TargetRoleRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+//TODO : 테스트 코드 작성
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+public class EventServiceTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventService eventService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private TargetRoleRepository targetRoleRepository;
+
+    @BeforeEach
+    void setUp() {
+        eventRepository.deleteAll();
+        targetRoleRepository.deleteAll();
+        targetRoleRepository.save(new TargetRole("PLANNER"));
+        targetRoleRepository.save(new TargetRole("DESIGNER"));
+        targetRoleRepository.save(new TargetRole("AI_DEVELOPER"));
+    }
+
+    private Event createEvent(String title) {
+        Set<TargetRole> roles = targetRoleRepository.findAll().stream()
+                .filter(r -> r.getName().equals("DESIGNER"))
+                .collect(Collectors.toSet());
+
+        return Event.builder()
+                .title(title)
+                .status(EventStatus.PUBLISHED)
+                .eventStart(LocalDateTime.of(2025, 9, 12, 10, 0))
+                .eventEnd(LocalDateTime.of(2025, 9, 12, 12, 0))
+                .thumbnailUrl("http://example.com/thumb.png")
+                .category(EventCategory.BOOTCAMP_CLUB)
+                .recruitEnd(LocalDateTime.of(2025, 9, 12, 12, 0))
+                .recruitStart(LocalDateTime.of(2025, 9, 12, 10, 0))
+                .isFree(true)
+                .price(null)
+                .isOnline(true)
+                .locationLink("http://example.com")
+                .locationText("test")
+                .applyLink("http://apply.example.com")
+                .contact("010-1234-5678")
+                .description("test")
+                .hashtags("#test")
+                .targetRoles(new HashSet<>(roles))
+                .build();
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"OWNER"})
+    void createEvent_Success_Test() throws Exception {
+        // given
+        EventRequest.CreateEvent request = new EventRequest.CreateEvent(
+                "행사 생성 테스트",
+                "http://example.com/thumb.png",
+                EventCategory.BOOTCAMP_CLUB,
+                LocalDateTime.of(2025, 9, 12, 10, 0),
+                LocalDateTime.of(2025, 9, 12, 12, 0),
+                LocalDateTime.of(2025, 9, 1, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 23, 59),
+                true,
+                null,
+                List.of("DESIGNER"),
+                false,
+                true,
+                "서울 올림픽공원",
+                "http://maps.example.com",
+                "http://apply.example.com",
+                "010-1234-5678",
+                "이벤트 설명입니다",
+                "#스포츠 , #러닝"
+        );
+
+        // when & then
+        mockMvc.perform(post("/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.eventId").isNumber())
+                .andExpect(jsonPath("$.message").value("행사가 등록되었습니다."))
+                .andExpect(jsonPath("$.code").value("SUCCESS"));
+
+        Event savedEvent = eventRepository.findAll().get(0);
+        assertThat(savedEvent.getTitle()).isEqualTo("행사 생성 테스트");
+        assertThat(savedEvent.getStatus()).isEqualTo(EventStatus.PUBLISHED);
+
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"OWNER"})
+    void createEvent_Draft_Success_Test() throws Exception {
+        EventRequest.CreateEvent request = new EventRequest.CreateEvent(
+                "임시 저장 테스트",
+                "http://example.com/thumb.png",
+                EventCategory.BOOTCAMP_CLUB,
+                LocalDateTime.of(2025, 9, 12, 10, 0),
+                LocalDateTime.of(2025, 9, 12, 12, 0),
+                LocalDateTime.of(2025, 9, 1, 0, 0),
+                LocalDateTime.of(2025, 9, 10, 23, 59),
+                true,
+                null,
+                List.of("DESIGNER"),
+                true,   // 임시 저장
+                false,
+                "서울 올림픽공원",
+                "http://maps.example.com",
+                "http://apply.example.com",
+                "010-1234-5678",
+                "임시 저장 설명",
+                "#테스트"
+        );
+
+        mockMvc.perform(post("/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.eventId").isNumber())
+                .andExpect(jsonPath("$.message").value("행사가 임시저장 되었습니다."))
+                .andExpect(jsonPath("$.code").value("SUCCESS"));
+
+        Event savedEvent = eventRepository.findAll().get(0);
+        assertThat(savedEvent.getStatus()).isEqualTo(EventStatus.DRAFT);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"OWNER"})
+    void deleteEvent_Success_Test() throws Exception {
+        Event event = eventRepository.save(createEvent("삭제용 test 엔티티"));
+
+        mockMvc.perform(delete("/events/{id}", event.getId())) // DELETE 메서드 사용
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("행사가 삭제되었습니다."))
+                .andExpect(jsonPath("$.code").value("SUCCESS"));
+
+        assertThat(eventRepository.existsById(event.getId())).isFalse();
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"OWNER"})
+    void updateEvent_Success_Test() throws Exception {
+        Event event = eventRepository.save(createEvent("원본 제목"));
+
+        EventRequest.UpdateEvent request = new EventRequest.UpdateEvent(
+                "수정된 제목",
+                "http://example.com/new-thumb.png",
+                EventCategory.COMPETITION_HACKATHON,
+                LocalDateTime.of(2025, 10, 1, 14, 0),
+                LocalDateTime.of(2025, 10, 1, 16, 0),
+                LocalDateTime.of(2025, 9, 15, 0, 0),
+                LocalDateTime.of(2025, 9, 30, 23, 59),
+                false,
+                20000,
+                List.of("PLANNER", "AI_DEVELOPER"),
+                true,
+                false,
+                "서울 코엑스",
+                "http://maps.example.com/new",
+                "http://apply.example.com/new",
+                "010-9876-5432",
+                "완전히 수정된 이벤트 설명",
+                "#AI , #워크숍"
+        );
+        mockMvc.perform(put("/events/{id}", event.getId()) // PUT 메서드 사용
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("행사가 수정되었습니다."))
+                .andExpect(jsonPath("$.code").value("SUCCESS"));
+
+        Event updatedEvent = eventRepository.findById(event.getId()).get();
+        assertThat(updatedEvent.getTitle()).isEqualTo("수정된 제목");
+        assertThat(updatedEvent.getThumbnailUrl()).isEqualTo("http://example.com/new-thumb.png");
+        assertThat(updatedEvent.getCategory()).isEqualTo(EventCategory.COMPETITION_HACKATHON);
+        assertThat(updatedEvent.getEventStart()).isEqualTo(LocalDateTime.of(2025, 10, 1, 14, 0));
+        assertThat(updatedEvent.getEventEnd()).isEqualTo(LocalDateTime.of(2025, 10, 1, 16, 0));
+        assertThat(updatedEvent.getRecruitStart()).isEqualTo(LocalDateTime.of(2025, 9, 15, 0, 0));
+        assertThat(updatedEvent.getRecruitEnd()).isEqualTo(LocalDateTime.of(2025, 9, 30, 23, 59));
+        assertThat(updatedEvent.getIsFree()).isFalse();
+        assertThat(updatedEvent.getPrice()).isEqualTo(20000);
+        assertThat(
+                updatedEvent.getTargetRoles().stream()
+                        .map(TargetRole::getName)
+                        .collect(Collectors.toList())
+        ).containsExactlyInAnyOrder("PLANNER", "AI_DEVELOPER");
+        assertThat(updatedEvent.getIsOnline()).isFalse();
+        assertThat(updatedEvent.getLocationText()).isEqualTo("서울 코엑스");
+        assertThat(updatedEvent.getLocationLink()).isEqualTo("http://maps.example.com/new");
+        assertThat(updatedEvent.getApplyLink()).isEqualTo("http://apply.example.com/new");
+        assertThat(updatedEvent.getContact()).isEqualTo("010-9876-5432");
+        assertThat(updatedEvent.getDescription()).isEqualTo("완전히 수정된 이벤트 설명");
+        assertThat(updatedEvent.getHashtags()).isEqualTo("#AI , #워크숍");
+        assertThat(updatedEvent.getStatus()).isEqualTo(EventStatus.DRAFT);
+    }
+
+}

--- a/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
@@ -32,7 +32,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
-//TODO : 테스트 코드 작성
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
@@ -92,7 +91,7 @@ public class EventServiceTest {
     @Test
     @WithMockUser(username = "admin", roles = {"OWNER"})
     void createEvent_Success_Test() throws Exception {
-        // given
+
         EventRequest.CreateEvent request = new EventRequest.CreateEvent(
                 "행사 생성 테스트",
                 "http://example.com/thumb.png",
@@ -114,7 +113,6 @@ public class EventServiceTest {
                 "#스포츠 , #러닝"
         );
 
-        // when & then
         mockMvc.perform(post("/events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -210,7 +208,7 @@ public class EventServiceTest {
                 .andExpect(jsonPath("$.message").value("행사가 수정되었습니다."))
                 .andExpect(jsonPath("$.code").value("SUCCESS"));
 
-        Event updatedEvent = eventRepository.findById(event.getId()).get();
+        Event updatedEvent = eventRepository.getEvent(event.getId());
         assertThat(updatedEvent.getTitle()).isEqualTo("수정된 제목");
         assertThat(updatedEvent.getThumbnailUrl()).isEqualTo("http://example.com/new-thumb.png");
         assertThat(updatedEvent.getCategory()).isEqualTo(EventCategory.COMPETITION_HACKATHON);
@@ -238,7 +236,7 @@ public class EventServiceTest {
     @Test
     @WithMockUser(username = "admin", roles = {"OWNER"})
     void hideEvent_Success_Test() throws Exception {
-        // given
+
         Event event = eventRepository.save(createEvent("숨김용 테스트 행사"));
 
         mockMvc.perform(patch("/events/{id}/hide", event.getId())
@@ -254,20 +252,19 @@ public class EventServiceTest {
     @Test
     @WithMockUser(username = "admin", roles = {"OWNER"})
     void publishEvent_Success_Test() throws Exception {
-        // given
+
         Event event = createEvent("공개용 테스트 행사");
-        // 먼저 숨김 처리 (상태를 맞춰줌)
+
         event.setStatus(EventStatus.HIDDEN);
         Event hidden_event = eventRepository.save(event);
 
-        // when & then
         mockMvc.perform(patch("/events/{id}/publish", hidden_event.getId())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("행사가 공개되었습니다."))
                 .andExpect(jsonPath("$.code").value("SUCCESS"));
 
-        // DB 검증
+
         Event publishedEvent = eventRepository.findById(hidden_event.getId()).orElseThrow();
         assertThat(publishedEvent.getStatus()).isEqualTo(EventStatus.PUBLISHED);
     }

--- a/src/test/java/com/example/skillup/global/auth/JwtProviderTest.java
+++ b/src/test/java/com/example/skillup/global/auth/JwtProviderTest.java
@@ -4,16 +4,18 @@ import com.example.skillup.global.auth.jwt.JwtProperties;
 import com.example.skillup.global.auth.jwt.JwtProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 import java.time.Duration;
-import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class JwtProviderTest {
 
     private final JwtProperties jwtProperties = new JwtProperties("my-secret-key-my-secret-key-my-secret-key", "U3VwZXJTZWNyZXRLZXlTdHJpbmdGb3JKV1QxMjM0NTY=");
-    private final JwtProvider jwtProvider = new JwtProvider(jwtProperties);
+    private final UserDetailsService userDetailsService = mock(UserDetailsService.class);
+    private final JwtProvider jwtProvider = new JwtProvider(jwtProperties , userDetailsService);
 
     @Test
     void testGenerateAndValidateToken() {


### PR DESCRIPTION
## 개요
Resolves: #3
- 이벤트 등록, 수정, 삭제, 숨김(HIDDEN), 공개(PUBLISHED), 상세 조회 API를 추가
- 이벤트 숨김/공개 처리 시 상태 검증 로직을 추가하여 이미 숨김/공개 상태일 경우 예외 처리하도록 개선
- 이벤트 상세 조회 시 관리자와 일반 사용자의 접근 권한을 구분하여 공개되지 않은 이벤트는 일반 사용자가 조회할 수 없도록 작성
- 성공시 response 및 DB 데이터 검증 테스트 추가
- 행사 등록 처리시 DB 에서 처리 안하는 버그 수정

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
