### PR TITLE
[FIX] 카테고리 페이지의 응답 dto를 HomeEventResponse로 수정

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -140,20 +140,19 @@ public class EventController {
 
     @PostMapping("/search")
     @Operation(summary = "행사 카테고리 페이지 검색 API(검색 조건이 많아 Json으로 보내기 위해서 Post 사용)", description="특정 조건의 행사들을 불러옵니다.")
-    public BaseResponse<List<EventResponse.EventSummaryResponse>> getEventBySearch(
+    public BaseResponse<List<EventResponse.HomeEventResponse>> getEventBySearch(
             @Valid @RequestBody EventRequest.EventSearchCondition condition
     ){
-        List<EventResponse.EventSummaryResponse> response = eventService.getEventBySearch(condition);
+        List<EventResponse.HomeEventResponse> response = eventService.getEventBySearch(condition);
         return BaseResponse.success("카테고리 페이지 검색 성공", response);
     }
     @GetMapping("/recommended")
-    public BaseResponse<List<EventResponse.EventSummaryResponse>> getRecommendedEvents(
+    public BaseResponse<List<EventResponse.HomeEventResponse>> getRecommendedEvents(
             @RequestParam EventCategory category) {
 
-        List<EventResponse.EventSummaryResponse> events = eventService.getRecommendedEvents(category);
+        List<EventResponse.HomeEventResponse> events = eventService.getRecommendedEvents(category);
         return BaseResponse.success("카테고리별 추천 이벤트 조회 성공",events);
     }
-
 
 
 }

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -142,26 +142,4 @@ public class EventMapper {
         return "마감 D-" + days;
     }
 
-
-
-    public EventResponse.EventSummaryResponse toEventSummaryInfo(Event event) {
-        return EventResponse.EventSummaryResponse.builder()
-                .id(event.getId())
-                .title(event.getTitle())
-                .thumbnailUrl(event.getThumbnailUrl())
-                .category(event.getCategory())
-                .eventStart(event.getEventStart())
-                .eventEnd(event.getEventEnd())
-                .recruitStart(event.getRecruitStart())
-                .recruitEnd(event.getRecruitEnd())
-                .isFree(event.getIsFree())
-                .price(event.getPrice())
-                .isOnline(event.getIsOnline())
-                .locationText(event.getLocationText())
-                .targetRoles(event.getTargetRoles()
-                        .stream()
-                        .map(TargetRole::getName)
-                        .collect(Collectors.toSet()))
-                .build();
-    }
 }

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
@@ -232,7 +232,6 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
         Long getLikesCnt();
         Double getPopularity();
     }
-
     // 위에는 점수까지 포함(test 용) 아래는 점수 포함하지 않은 쿼리문
     @Query("""
     select e

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryImpl.java
@@ -2,26 +2,78 @@ package com.example.skillup.domain.event.repository;
 
 import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.entity.Event;
+import com.example.skillup.domain.event.enums.EventCategory;
+import com.example.skillup.domain.event.enums.EventStatus;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Pageable;
 
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
 public class EventRepositoryImpl implements EventRepositoryNative {
 
     private final EntityManager entityManager;
-
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    static public class EventWithPopularity {
+        private Event event;
+        private Double popularity;
+    }
+    private LocalDateTime convertToLocalDateTime(Object value) {
+        if (value == null) return null;
+        else {
+            if (value instanceof Timestamp ts) return ts.toLocalDateTime();
+            if (value instanceof LocalDateTime dt) return dt;
+        }
+        return null;
+    }
     @Override
-    public List<Event> searchEvents(EventRequest.EventSearchCondition cond, Pageable pageable, LocalDate since, LocalDateTime now) {
+    public List<EventWithPopularity> findByCategoryWithSearch(EventRequest.EventSearchCondition cond, Pageable pageable, LocalDate since, LocalDateTime now) {
 
         String baseQuery = """
-        SELECT e.*
+        SELECT                e.id,e.title,
+                              e.thumbnail_url,
+                              e.category,
+                              e.event_start,
+                              e.event_end,
+                              e.recruit_start,
+                              e.recruit_end,
+                              e.is_free,
+                              e.price,
+                              e.is_online,
+                              e.location_text,
+                              e.location_link,
+                              e.apply_link,
+                              e.status,
+                              e.contact,
+                              e.description,
+                              e.hashtags,
+                              e.views_count,
+                              e.likes_count,
+                              e.apply_clicks,
+                              e.recommended_manual,
+                              e.ad_flag,
+               (
+                coalesce(sum(v.cnt), 0) * 0.6
+                + count(DISTINCT el.id) * 0.3
+                + (
+                    CASE WHEN coalesce(sum(v.cnt), 0) > 0
+                            THEN (1.0 * e.apply_clicks / coalesce(sum(v.cnt), 1))
+                            ELSE 0
+                    END
+                ) * 0.1
+               ) AS popularity
         FROM event e
         LEFT JOIN event_view_daily v ON v.event_id = e.id AND v.created_at >= :since
         LEFT JOIN event_like el ON el.event_id = e.id AND el.created_at >= :since
@@ -40,21 +92,10 @@ public class EventRepositoryImpl implements EventRepositoryNative {
         String orderBy = switch (cond.getSort()) {
             case "latest" -> " ORDER BY e.created_at DESC";
             case "deadline" -> " ORDER BY e.recruit_end ASC";
-            default -> """
-            ORDER BY (
-              coalesce(sum(v.cnt), 0) * 0.6
-              + count(DISTINCT el.id) * 0.3
-              + (
-                  CASE WHEN coalesce(sum(v.cnt), 0) > 0
-                       THEN (1.0 * e.apply_clicks / coalesce(sum(v.cnt), 1))
-                       ELSE 0
-                  END
-              ) * 0.1
-            ) DESC
-            """;
+            default -> " ORDER BY popularity DESC";
         };
 
-        Query query = entityManager.createNativeQuery(baseQuery + orderBy, Event.class)
+        Query query = entityManager.createNativeQuery(baseQuery + orderBy)
                 .setParameter("category", cond.getCategory().name())
                 .setParameter("isOnline", cond.getIsOnline())
                 .setParameter("isFree", cond.getIsFree())
@@ -68,7 +109,41 @@ public class EventRepositoryImpl implements EventRepositoryNative {
         query.setFirstResult((int) pageable.getOffset());
         query.setMaxResults(pageable.getPageSize());
 
-        return query.getResultList();
+
+        List<Object[]> resultList = query.getResultList();
+        List<EventWithPopularity> results = new ArrayList<>();
+
+        for (Object[] row : resultList) {
+            Event event = Event.builder()
+                    .id(((Number) row[0]).longValue())
+                    .title((String) row[1])
+                    .thumbnailUrl((String) row[2])
+                    .category(EventCategory.valueOf((String) row[3]))
+                    .eventStart(convertToLocalDateTime(row[4]))
+                    .eventEnd(convertToLocalDateTime(row[5]))
+                    .recruitStart(convertToLocalDateTime(row[6]))
+                    .recruitEnd(convertToLocalDateTime(row[7]))
+                    .isFree((Boolean) row[8])
+                    .price(row[9] != null ? ((Number) row[9]).intValue() : null)
+                    .isOnline((Boolean) row[10])
+                    .locationText((String) row[11])
+                    .locationLink((String) row[12])
+                    .applyLink((String) row[13])
+                    .status(EventStatus.valueOf((String) row[14]))
+                    .contact((String) row[15])
+                    .description((String) row[16])
+                    .hashtags((String) row[17])
+                    .viewsCount(((Number) row[18]).longValue())
+                    .likesCount(((Number) row[19]).longValue())
+                    .applyClicks(((Number) row[20]).longValue())
+                    .recommendedManual((Boolean) row[21])
+                    .ad((Boolean) row[22])
+                    .build();
+            Double popularity = row[23] != null ? ((Number) row[23]).doubleValue() : 0.0;
+
+            results.add(new EventWithPopularity(event, popularity));
+        }
+        return results;
     }
 }
 

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryNative.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryNative.java
@@ -9,5 +9,5 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface EventRepositoryNative {
-    List<Event> searchEvents(EventRequest.EventSearchCondition cond, Pageable pageable, LocalDate date, LocalDateTime now);
+    List<EventRepositoryImpl.EventWithPopularity> findByCategoryWithSearch(EventRequest.EventSearchCondition cond, Pageable pageable, LocalDate date, LocalDateTime now);
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

1. getEventBySearch, getRecommendedEvents의 응답 response를 HomeEventResponse로 수정하였습니다

2. mapper에서 EventSummaryResponse 삭제

3. EventRepositoryImpl 수정하였습니다 기존에는 select로 가져오는 게 event뿐이라서
Query query = entityManager.createNativeQuery(baseQuery + orderBy, Event.class) 부분에서 Event.class를 매개변수로 넘겨 주면 알아서 jpa가 매핑을 해줬으나  popularity도 같이 가져오는 것으로 수정되니 수동 매핑을 해야해서 select으로 일일히 명시해서 수동 매핑 해줬습니다.. 

4. etEventBySearch_Popularity_Test()부분에서 리플렉션으로 createdAt을 수정하면 변경되는 줄 알았으나 DB에 save하는 과정에서 jpa가 now로 값을 덮어 씌워 3달 이전, 이후 조회수로는 테스트를 진행 못했네요..




## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
