### PR TITLE
[FIX] 일반 유저 로그인으로 변경 및 이벤트 검색시 이벤트 개수 반환으로 변경

### DIFF
--- a/.github/workflows/DEV-CI-CD.yml
+++ b/.github/workflows/DEV-CI-CD.yml
@@ -48,7 +48,8 @@ jobs:
             sudo docker compose pull
 
             echo "📦 기존 컨테이너 제거"
-            sudo docker compose down
+            docker compose down --rmi all --volumes
+            
             echo "🚀 서비스 재시작"
             sudo docker compose up -d
 

--- a/.github/workflows/DEV-CI-CD.yml
+++ b/.github/workflows/DEV-CI-CD.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          docker build -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.IMAGE_NAME }}:dev .
+          docker build  -f Dockerfile_dev -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.IMAGE_NAME }}:dev .
 
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin

--- a/.github/workflows/DEV-CI-CD.yml
+++ b/.github/workflows/DEV-CI-CD.yml
@@ -53,4 +53,13 @@ jobs:
             echo "🚀 서비스 재시작"
             sudo docker compose up -d
 
+            echo "⏳ MySQL 부팅 대기중..."
+            until docker exec skillup-mysql mysqladmin ping -uroot -p${{ secrets.MYSQL_ROOT_PASSWORD }} --silent; do
+              sleep 1
+            done
+
+            
+            docker exec -i skillup-mysql sh -c "mysql -uroot -p${{ secrets.MYSQL_ROOT_PASSWORD }} skillup" < seed.sql
+            echo "🎉 Seed 데이터 삽입 성공"
+      
             echo "🎉 DEV 배포 완료!"

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:17-jdk
+
+WORKDIR /app
+
+COPY build/libs/SkillUp-0.0.1-SNAPSHOT.jar app.jar
+  
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -142,10 +142,10 @@ public class EventController {
 
     @PostMapping("category-page/search")
     @Operation(summary = "행사 카테고리 페이지에서 검색하는 API(검색 조건이 많아 Json으로 보내기 위해서 Post 사용)", description="특정 조건의 행사들을 불러옵니다.")
-    public BaseResponse<List<EventResponse.HomeEventResponse>> getEventBySearch(
+    public BaseResponse<EventResponse.SearchEventResponseList> getEventBySearch(
             @Valid @RequestBody EventRequest.EventSearchCondition condition
     ){
-        List<EventResponse.HomeEventResponse> response = eventService.getEventBySearch(condition);
+        EventResponse.SearchEventResponseList response = eventService.getEventBySearch(condition);
         return BaseResponse.success("카테고리 페이지 검색 성공", response);
     }
     @GetMapping("category-page/recommended")

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -112,8 +113,9 @@ public class EventResponse {
 
     @Getter @Builder
     public static class SearchEventResponseList{
-        private Integer total;
-        private List<HomeEventResponse> homeEventResponseList;
+        private int total;
+        @Builder.Default
+        private List<HomeEventResponse> homeEventResponseList = Collections.emptyList();
     }
 
     @Getter @Builder

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
@@ -1,5 +1,6 @@
 package com.example.skillup.domain.event.repository;
 
+import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.exception.EventErrorCode;
@@ -276,6 +277,28 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
 
 
 
+    @Query(value = """
+    SELECT COUNT(DISTINCT e.id)
+    FROM event e
+    LEFT JOIN event_target_role etr ON etr.event_id = e.id
+    LEFT JOIN target_role tr ON tr.id = etr.role_id
+    WHERE (:category IS NULL OR e.category = :category)
+      AND (e.event_end IS NULL OR e.event_end >= :now)
+      AND (e.status = 'PUBLISHED')
+      AND (:isOnline IS NULL OR e.is_online = :isOnline)
+      AND (:isFree IS NULL OR e.is_free = :isFree)
+      AND (:startDate IS NULL OR e.event_start BETWEEN :startDate AND :endDate)
+      AND (:targetRoles IS NULL OR tr.name IN (:targetRoles))
+""", nativeQuery = true)
+    int countByCategoryWithSearch(
+            @Param("category") String category,
+            @Param("isOnline") Boolean isOnline,
+            @Param("isFree") Boolean isFree,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("targetRoles") List<String> targetRoles,
+            @Param("now") LocalDateTime now
+    );
 
 
 

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryImpl.java
@@ -105,7 +105,6 @@ public class EventRepositoryImpl implements EventRepositoryNative {
                 .setParameter("since", since)
                 .setParameter("now", now);
 
-
         query.setFirstResult((int) pageable.getOffset());
         query.setMaxResults(pageable.getPageSize());
 

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -323,17 +323,20 @@ public class EventService {
 
     @Transactional(readOnly = true)
     @HandleDataAccessException
-    public List<EventResponse.HomeEventResponse> getEventBySearch(EventRequest.EventSearchCondition condition) {
+    public EventResponse.SearchEventResponseList getEventBySearch(EventRequest.EventSearchCondition condition) {
         Pageable pageable = PageRequest.of(condition.getPage(), 12);
         List<EventRepositoryImpl.EventWithPopularity> events = eventRepository.findByCategoryWithSearch(condition,
                 pageable, since, now);
-        return events.stream()
+        int count=eventRepository.countByCategoryWithSearch(condition.getCategory().name(),condition.getIsOnline()
+                ,condition.getIsFree(),condition.getStartDate(),condition.getEndDate(),condition.getTargetRoles(),now);
+
+        return EventResponse.SearchEventResponseList.builder().homeEventResponseList(events.stream()
                 .map(r -> {
                     Event event = r.getEvent();
                     double score = r.getPopularity();
                     return eventMapper.toFeaturedEvent(event, false, event.isRecommendedManual(), event.isAd(), score);
                 })
-                .toList();
+                .toList()).total(count).build();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/skillup/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/skillup/domain/user/controller/UserController.java
@@ -1,8 +1,11 @@
 package com.example.skillup.domain.user.controller;
 
 
+import com.example.skillup.domain.admin.enums.AdminRole;
 import com.example.skillup.domain.user.dto.response.UserResponseDto;
 import com.example.skillup.domain.user.service.UserService;
+import com.example.skillup.global.auth.dto.response.TokenResponse;
+import com.example.skillup.global.auth.service.AuthService;
 import com.example.skillup.global.common.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,10 +20,16 @@ import java.util.List;
 public class UserController
 {
     private final UserService userService;
-
+    private final AuthService authService;
     @GetMapping("/all")
     public BaseResponse<List<UserResponseDto>> findAll()
     {
         return  BaseResponse.success("회원조회에 성공했습니다.",userService.findAll());
+    }
+
+    @GetMapping("/test-login")
+    public BaseResponse<String> testLogin()
+    {
+        return BaseResponse.success("테스트 용 엑세스 토큰입니다(모든 권한 허용)",authService.login(null, AdminRole.OWNER.toString()).accessToken());
     }
 }

--- a/src/main/java/com/example/skillup/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/skillup/domain/user/controller/UserController.java
@@ -30,6 +30,6 @@ public class UserController
     @GetMapping("/test-login")
     public BaseResponse<String> testLogin()
     {
-        return BaseResponse.success("테스트 용 엑세스 토큰입니다(모든 권한 허용)",authService.login(null, AdminRole.OWNER.toString()).accessToken());
+        return BaseResponse.success("테스트 용 엑세스 토큰입니다(모든 권한 허용)",authService.login(1L, "users").accessToken());
     }
 }

--- a/src/main/java/com/example/skillup/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/example/skillup/global/config/ElasticsearchConfig.java
@@ -8,11 +8,15 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ElasticsearchConfig {
+
+    @Value("${spring.elasticsearch.uris}")
+    private String esUrl;
 
     @Bean
     public ElasticsearchClient elasticsearchClient() {
@@ -22,7 +26,7 @@ public class ElasticsearchConfig {
 
         JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper(om);
 
-        RestClient lowLevel = RestClient.builder(HttpHost.create("http://localhost:9200")).build();
+        RestClient lowLevel = RestClient.builder(HttpHost.create(esUrl)).build();
         RestClientTransport transport = new RestClientTransport(lowLevel, jsonpMapper);
         return new ElasticsearchClient(transport);
     }
@@ -30,6 +34,6 @@ public class ElasticsearchConfig {
     @Bean
     public org.elasticsearch.client.RestClient lowLevelRestClient() {
         // 실제 운영에선 yml 또는 .env 파일에 경로 설정하기
-        return org.elasticsearch.client.RestClient.builder(HttpHost.create("http://localhost:9200")).build();
+        return org.elasticsearch.client.RestClient.builder(HttpHost.create(esUrl)).build();
     }
 }

--- a/src/main/java/com/example/skillup/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/skillup/global/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/*").permitAll()
                         .requestMatchers("/events/closing-soon").permitAll()
                         .requestMatchers("/oauth/**").permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 ).cors(cors -> cors.configurationSource(corsConfigurationSource()));
         return http.build();
     }

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     container_name: kibana
     environment:
       - SERVER_NAME=kibana
+      - SERVER_HOST=0.0.0.0
       - ELASTICSEARCH_HOSTS=http://es:9200
     ports:
     - "5601:5601"

--- a/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
@@ -316,16 +316,17 @@ public class EventServiceTest {
 
         for(int i=0;i<20;i++)
             eventRepository.save(createEvent("저장",EventCategory.CONFERENCE_SEMINAR));
-        List<EventResponse.HomeEventResponse> resultByCategory
+        EventResponse.SearchEventResponseList resultByCategory
                 = eventService.getEventBySearch
                 (EventRequest.EventSearchCondition.builder().category(EventCategory.CONFERENCE_SEMINAR).sort("latest").page(0).build());
-        List<EventResponse.HomeEventResponse> resultByCategory2
+        EventResponse.SearchEventResponseList resultByCategory2
                 = eventService.getEventBySearch
                 (EventRequest.EventSearchCondition.builder().category(EventCategory.CONFERENCE_SEMINAR).sort("latest").page(1).build());
 
-        assertThat(resultByCategory).isNotEmpty();
-        assertEquals(12, resultByCategory.size());
-        assertEquals(8, resultByCategory2.size());
+        assertThat(resultByCategory).isNotNull();
+        System.out.println(resultByCategory.getTotal());
+        assertEquals(12, resultByCategory.getHomeEventResponseList().size());
+        assertEquals(8, resultByCategory2.getHomeEventResponseList().size());
     }
 
     @Test
@@ -443,26 +444,29 @@ public class EventServiceTest {
 
 
 
-        List<EventResponse.HomeEventResponse> resultsByPopularity = eventService.getEventBySearch(condPopularity);
+        EventResponse.SearchEventResponseList resultsByPopularity = eventService.getEventBySearch(condPopularity);
 
-        List<EventResponse.HomeEventResponse> resultsByLatest = eventService.getEventBySearch(condLatest);
+        EventResponse.SearchEventResponseList resultsByLatest = eventService.getEventBySearch(condLatest);
 
-        List<EventResponse.HomeEventResponse> resultsByDeadLine = eventService.getEventBySearch(condDeadline);
+        EventResponse.SearchEventResponseList resultsByDeadLine = eventService.getEventBySearch(condDeadline);
 
         // assertions
-        assertThat(resultsByDeadLine).isNotEmpty();
-        assertThat(resultsByDeadLine.get(0).getId()).isEqualTo(event2.getId());
+        assertThat(resultsByDeadLine).isNotNull();
+        assertThat(resultsByDeadLine.getHomeEventResponseList().get(0).getId()).isEqualTo(event2.getId());
+        assertThat(resultsByDeadLine.getTotal()).isEqualTo(resultsByPopularity.getTotal());
 
-        assertThat(resultsByLatest).isNotEmpty();
-        assertThat(resultsByLatest.get(0).getId()).isEqualTo(event3.getId());
+        assertThat(resultsByLatest).isNotNull();
+        assertThat(resultsByLatest.getHomeEventResponseList().get(0).getId()).isEqualTo(event3.getId());
 
-        assertThat(resultsByPopularity).isNotEmpty();
-        assertThat(resultsByPopularity.get(0).getId()).isEqualTo(event2.getId());
+        assertThat(resultsByPopularity).isNotNull();
+        assertThat(resultsByPopularity.getHomeEventResponseList().get(0).getId()).isEqualTo(event2.getId());
 
-        for(EventResponse.HomeEventResponse event :resultsByPopularity)
+        for(EventResponse.HomeEventResponse event :resultsByPopularity.getHomeEventResponseList())
         {
             System.out.println(event.getRecommendedRate());
         }
+
+        System.out.println(resultsByLatest.getTotal());
 
 
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

테스트 로그인을 목업 데이터에 있는 id값 1인 일반 유저 로그인으로 변경하였습니다. 
이벤트 개수 값을 리턴 할 수 있게 변경하였습니다.
CI-CD에 목업 데이터를 넣는 로직을 추가하였습니다.

sql파일입니다
[seed.sql](https://github.com/user-attachments/files/23618211/seed.sql)


## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
