### PR TITLE
[FEAT]행사 신청 API 및 신청 수 집계 로직 추가

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -2,6 +2,7 @@ package com.example.skillup.domain.event.controller;
 
 import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.dto.response.EventResponse;
+import com.example.skillup.domain.event.dto.response.EventResponse.EventApplyResponse;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventBookmark;
 import com.example.skillup.domain.event.enums.EventCategory;
@@ -85,7 +86,7 @@ public class EventController {
             @AuthenticationPrincipal UsersDetails user
     ) {
         EventBookmark eventBookmark = eventBookmarkService.updateBookmarked(user, eventId);
-        return BaseResponse.success("북마크가 수정되었습니다." , "북마크 상태 " + eventBookmark.getIsBookmarked().toString());
+        return BaseResponse.success("북마크가 수정되었습니다.", "북마크 상태 " + eventBookmark.getIsBookmarked().toString());
     }
 
 
@@ -200,6 +201,17 @@ public class EventController {
             @Valid @ModelAttribute EventRequest.EventSearchRequest request) {
         return BaseResponse.success("검색 성공", eventSearchService.search(request));
 
+    }
+
+    @PatchMapping("/{eventId}/apply")
+    @Operation(summary = "행사 신청 api",
+            description = "행사 신청률 측정을 위한 api 입니다. 행사에서 지원버튼을 누를때를 기준으로 하며 이미 신청한 경우 증가하지 않습니다.")
+    public BaseResponse<EventApplyResponse> applyEvent(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal UsersDetails user,
+            @CookieValue(required = false) String guestId
+    ) {
+        return BaseResponse.success("지원 성공", eventService.applyEvent(eventId, user, guestId));
     }
 
 }

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -78,7 +78,8 @@ public class EventResponse {
         private Set<String> targetRoles;
     }
 
-    @Getter @Builder
+    @Getter
+    @Builder
     public static class HomeEventResponse {
         private Long id;
         private String thumbnailUrl;
@@ -101,27 +102,31 @@ public class EventResponse {
         private Double recommendedRate;
     }
 
-    @Getter @Builder
+    @Getter
+    @Builder
     public static class featuredEventResponseList {
         private String tab;               //  ex )"IT 전체", "기획", "디자인", "개발", "AI"
         private List<HomeEventResponse> homeEventResponseList;
     }
-    @Getter @Builder
+
+    @Getter
+    @Builder
     public static class CategoryEventResponseList {
         private EventCategory category;
         private List<HomeEventResponse> homeEventResponseList;
     }
 
-    @Getter @Builder
-    public static class SearchEventResponseList{
+    @Getter
+    @Builder
+    public static class SearchEventResponseList {
         private int total;
         @Builder.Default
         private List<HomeEventResponse> homeEventResponseList = Collections.emptyList();
     }
 
-    @Getter @Builder
-    public static class EventBannerResponse
-    {
+    @Getter
+    @Builder
+    public static class EventBannerResponse {
         private int displayOrder;
 
         private String title;
@@ -132,9 +137,19 @@ public class EventResponse {
 
     }
 
-    @Getter @Builder @AllArgsConstructor
+    @Getter
+    @Builder
+    @AllArgsConstructor
     public static class EventBannersResponseList {
         private List<EventBannerResponse> eventMainBannerReponseList;
         private List<EventBannerResponse> eventSubBannerResponse;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class EventApplyResponse{
+        private Long eventId;
+        private String comment;
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/repository/EventActionRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventActionRepository.java
@@ -23,5 +23,7 @@ public interface EventActionRepository extends JpaRepository<EventAction, Long> 
 """)
     List<Event> findRecentEventsByActorId(@Param("actorId")String actorId, Pageable pageable);
 
+    List<EventAction> findAllByEventAndActionType(Event event, ActionType actionType);
+
     Optional<EventAction> findByEventAndActorIdAndActionType(Event event, String actorId , ActionType actionType);
 }

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
@@ -26,6 +26,10 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
     @Query(value = "UPDATE event SET views_count = views_count + 1 , updated_at = CURRENT_TIMESTAMP WHERE id = :eventId", nativeQuery = true)
     void incrementViews(@Param("eventId") Long eventId);
 
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE event SET apply_clicks = apply_clicks + 1 , updated_at = CURRENT_TIMESTAMP WHERE id = :eventId", nativeQuery = true)
+    void incrementApplys(@Param("eventId") Long eventId);
+
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -2,6 +2,7 @@ package com.example.skillup.domain.event.service;
 
 import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.dto.response.EventResponse;
+import com.example.skillup.domain.event.dto.response.EventResponse.EventApplyResponse;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventAction;
 import com.example.skillup.domain.event.entity.EventBanner;
@@ -236,7 +237,8 @@ public class EventService {
         //전체 조회수 및 event_view_daily 업데이트
         eventViewService.recordView(event.getId());
 
-        Optional<EventAction> eventAction = eventActionRepository.findByEventAndActorIdAndActionType(event, actorId,ActionType.VIEW);
+        Optional<EventAction> eventAction = eventActionRepository.findByEventAndActorIdAndActionType(event, actorId,
+                ActionType.VIEW);
 
         if (eventAction.isPresent()) {
             eventAction.get().setUpdatedAt();
@@ -455,5 +457,38 @@ public class EventService {
                 })
                 .toList();
 
+    }
+
+    @Transactional
+    public EventResponse.EventApplyResponse applyEvent(Long eventId, UsersDetails users, String guestId) {
+        Event event = eventRepository.getEvent(eventId);
+
+        String actorId = (users != null) ? users.getUser().getId().toString() : guestId;
+
+        Optional<EventAction> eventAction = eventActionRepository.findByEventAndActorIdAndActionType(event, actorId, ActionType.APPLY);
+        if(eventAction.isPresent()) {
+            return EventResponse.EventApplyResponse.builder()
+                    .eventId(eventId)
+                    .comment("이미 신청한 이력이 있습니다. 정상적으로 처리 되었습니다.")
+                    .build();
+        }
+
+        ActorType actorType = users != null ? ActorType.USER : ActorType.GUEST;
+
+        EventAction newEventAction = EventAction.builder()
+                .event(event)
+                .actorId(actorId)
+                .actorType(actorType)
+                .actionType(ActionType.APPLY)
+                .build();
+
+       eventRepository.incrementApplys(eventId);
+
+        eventActionRepository.save(newEventAction);
+
+        return EventApplyResponse.builder()
+                .eventId(eventId)
+                .comment("성공적으로 신청되었습니다.")
+                .build();
     }
 }

--- a/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
@@ -641,16 +641,16 @@ public class EventServiceTest {
 
         assertThat(reloadEvent.getViewsCount()).isEqualTo(1L);
 
-        Optional<EventViewDaily> eventViewDaily = eventViewDailyRepository.findByEventAndViewDate(reloadEvent , LocalDate.now());
+        Optional<EventViewDaily> eventViewDaily = eventViewDailyRepository.findByEventAndViewDate(reloadEvent,
+                LocalDate.now());
         assertThat(eventViewDaily).isPresent();
         assertThat(eventViewDaily.get().getCnt()).isEqualTo(1L);
 
-
         Optional<EventAction> EventAction =
-                eventActionRepository.findByEventAndActorIdAndActionType(reloadEvent, principal.getUser().getId().toString() , ActionType.VIEW);
+                eventActionRepository.findByEventAndActorIdAndActionType(reloadEvent,
+                        principal.getUser().getId().toString(), ActionType.VIEW);
         assertThat(EventAction).isPresent();
         assertThat(EventAction.get().getActorType()).isEqualTo(ActorType.USER);
-
 
         String guestId = "guest-123";
 
@@ -661,14 +661,104 @@ public class EventServiceTest {
         reloadEvent = eventRepository.getEvent(result2.getId());
 
         assertThat(reloadEvent.getViewsCount()).isEqualTo(2L);
-        eventViewDaily = eventViewDailyRepository.findByEventAndViewDate(reloadEvent , LocalDate.now());
+        eventViewDaily = eventViewDailyRepository.findByEventAndViewDate(reloadEvent, LocalDate.now());
         assertThat(eventViewDaily).isPresent();
         assertThat(eventViewDaily.get().getCnt()).isEqualTo(2L);
 
         EventAction =
-                eventActionRepository.findByEventAndActorIdAndActionType(reloadEvent, guestId , ActionType.VIEW);
+                eventActionRepository.findByEventAndActorIdAndActionType(reloadEvent, guestId, ActionType.VIEW);
         assertThat(EventAction).isPresent();
         assertThat(EventAction.get().getActorType()).isEqualTo(ActorType.GUEST);
+    }
+
+    @Test
+    @DisplayName("행사 신청 시 EventAction 이 존재하지 않으면 신청 수 1 증가하고 EventAction 을 만든다. 성공 테스트")
+    void applyEventUser_Success() {
+        Event event = eventRepository.save(createEvent("저장"));
+
+        Users user = Users.builder()
+                .id(1L)
+                .email("test@example.com")
+                .name("Seed1")
+                .gender("남")
+                .age("15")
+                .jobGroup("개발자")
+                .notificationFlag("Y")
+                .socialId("test")
+                .regDatetime(LocalDateTime.now())
+                .socialLoginType(SocialLoginType.google)
+                .lastLoginAt(LocalDateTime.now())
+                .status(UserStatus.ACTIVE)
+                .role("USER")
+                .build();
+
+        UsersDetails usersDetails = new UsersDetails(user);
+
+        EventResponse.EventApplyResponse eventApplyResponse = eventService.applyEvent(event.getId(), usersDetails,
+                null);
+
+        assertThat(eventApplyResponse).isNotNull();
+        assertThat(eventApplyResponse.getComment()).isEqualTo("성공적으로 신청되었습니다.");
+
+        Event newEvent = eventRepository.getEvent(event.getId());
+        Optional<EventAction> eventAction = eventActionRepository.findByEventAndActorIdAndActionType(newEvent,
+                user.getId().toString(), ActionType.APPLY);
+
+        assertThat(eventAction).isPresent();
+        assertThat(eventAction.get().getActorType()).isEqualTo(ActorType.USER);
+        assertThat(eventAction.get().getActionType()).isEqualTo(ActionType.APPLY);
+
+        assertThat(newEvent.getApplyClicks()).isEqualTo(1L);
+
+    }
+
+    @Test
+    @DisplayName("행사 신청 시 EventAction 이 존재하면 신청 수 증가하지않고 반환. 성공 테스트")
+    void applyEventDuplicateUser_Success() {
+        Event event = eventRepository.save(createEvent("저장"));
+
+        Users user = Users.builder()
+                .id(1L)
+                .email("test@example.com")
+                .name("Seed1")
+                .gender("남")
+                .age("15")
+                .jobGroup("개발자")
+                .notificationFlag("Y")
+                .socialId("test")
+                .regDatetime(LocalDateTime.now())
+                .socialLoginType(SocialLoginType.google)
+                .lastLoginAt(LocalDateTime.now())
+                .status(UserStatus.ACTIVE)
+                .role("USER")
+                .build();
+
+        UsersDetails usersDetails = new UsersDetails(user);
+
+        eventActionRepository.save(
+                EventAction.builder()
+                        .actionType(ActionType.APPLY)
+                        .actorId(user.getId().toString())
+                        .actorType(ActorType.USER)
+                        .event(event)
+                        .build()
+        );
+
+        EventResponse.EventApplyResponse eventApplyResponse = eventService.applyEvent(event.getId(), usersDetails,
+                null);
+
+        assertThat(eventApplyResponse).isNotNull();
+        assertThat(eventApplyResponse.getComment()).isEqualTo("이미 신청한 이력이 있습니다. 정상적으로 처리 되었습니다.");
+
+        Event newEvent = eventRepository.getEvent(event.getId());
+
+        List<EventAction> actions =
+                eventActionRepository.findAllByEventAndActionType(event, ActionType.APPLY);
+
+        assertThat(actions).hasSize(1);
+
+        assertThat(newEvent.getApplyClicks()).isEqualTo(0L);
+
     }
 
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->



> **행사 신청률 증가 api 가 존재하지 않아서 만들었습니다.
user 와 guest 모두 사용하도록 만들면서 EventAction 에서의 확인을 통해서 중복 처리가 되지 않게끔 구현했습니다.**

## 주요 변경 사항

### 1. 행사 신청 API 엔드포인트 추가

- `EventController`
  - `@PatchMapping("/{eventId}/apply")`
  - 파라미터
    - `@PathVariable Long eventId`
    - `@AuthenticationPrincipal UsersDetails user`
    - `@CookieValue(required = false) String guestId`
  - 응답
    - `BaseResponse<EventApplyResponse>` 형태로 래핑하여 반환
    - 성공 시 `"지원 성공"` 메시지와 함께 서비스 결과 반환

### 2. 행사 신청 응답 DTO 추가

- `EventResponse.EventApplyResponse`

### 3. 행사 신청 서비스 로직 구현

- `EventService.applyEvent(Long eventId, UsersDetails users, String guestId)`
  - 동작 흐름
    1. `eventRepository.getEvent(eventId)`로 대상 `Event` 조회
    2. `actorId` 결정
       - 로그인 사용자: `users.getUser().getId().toString()`
       - 비로그인(게스트): `guestId` 쿠키 값 사용
    3. 중복 신청 여부 확인
       - `eventActionRepository.findByEventAndActorIdAndActionType(event, actorId, ActionType.APPLY)`
       - 이미 존재하는 경우
         - `apply_clicks` 증가 없이
         - `eventId`, `"이미 신청한 이력이 있습니다. 정상적으로 처리 되었습니다."` 메시지로 응답
    4. 신규 신청 처리
       - `ActorType` 결정
         - 로그인: `ActorType.USER`
         - 게스트: `ActorType.GUEST`
       - 신청 수 증가
         - `eventRepository.incrementApplys(eventId)` 호출
       - 응답
         - `eventId`, `"성공적으로 신청되었습니다."` 메시지로 응답

### 4. 신청 수 증가 쿼리 추가

- `EventRepository.incrementApplys(Long eventId)`
  - 어노테이션
    - `@Modifying(clearAutomatically = true)`
    - `@Query(..., nativeQuery = true)`
  - 쿼리 내용
    - `apply_clicks = apply_clicks + 1`
    - `updated_at = CURRENT_TIMESTAMP`
    - `WHERE id = :eventId`
  - 비고
    - 네이티브 UPDATE를 사용해 **동시성 상황에서도 카운트가 안전하게 증가**하도록 처리
    - `clearAutomatically = true`로 bulk update 이후 영속성 컨텍스트를 정리하여, 이후 조회 시 최신 값이 보장되도록 함

---

## 테스트
### 1. 행사 신청 최초 요청 시

- `applyEventUser_Success`
  - **실행**
    - `eventService.applyEvent(event.getId(), usersDetails, null)` 호출
  - **검증**
    - **응답 본문**
      - `comment = "성공적으로 신청되었습니다."`
    - **EventActionRepository**
      - `findByEventAndActorIdAndActionType(event, actorId, APPLY)` 결과가 `isPresent()`
      - `actorType = USER`, `actionType = APPLY`
    - **Event**
      - `eventRepository.getEvent(eventId).getApplyClicks() == 1L`

### 2. 이미 신청된 행사에 재요청 시

- `applyEventDuplicateUser_Success`
  - **준비**
    - 동일 `actorId` / `ActionType.APPLY` 로 `EventAction` 미리 저장
  - **실행**
    - `eventService.applyEvent(event.getId(), usersDetails, null)` 호출
  - **검증**
    - **응답 본문**
      - `comment = "이미 신청한 이력이 있습니다. 정상적으로 처리 되었습니다."`
    - **EventActionRepository**
      - `findAllByEventAndActionType(event, APPLY)` 결과 `size == 1`
      - 중복 신청으로 인한 `EventAction` 추가 생성 없음
    - **Event**
      - `eventRepository.getEvent(eventId).getApplyClicks() == 0L`
      - 이미 존재하는 신청 이력에 대해서는 신청 수가 증가하지 않음



## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
