### PR TITLE
[FIX] userService 부분에 User객체가 영속성 컨텍스트가 아니라 발생한 오류 수정

### DIFF
--- a/src/main/java/com/example/skillup/domain/user/service/UserService.java
+++ b/src/main/java/com/example/skillup/domain/user/service/UserService.java
@@ -41,6 +41,7 @@ public class UserService
     final private EventMapper eventMapper;
     final private TargetRoleRepository targetRoleRepository;
     final private InquiryRepository inquiryRepository;
+    private final UserRepository userRepository;
 
     public UserResponse.MyPageHomeResponse getMyPageHome(Users user)
     {
@@ -53,7 +54,8 @@ public class UserService
         List<Event> eventBookmarks=new ArrayList<>();
         Pageable pageable = PageRequest.of(page, 9);
 
-
+        //user를 영속성 컨텍스트로 만들기 위해서
+        user=userRepository.findById(user.getId()).orElse(null);
 
         switch (sort) {
             case "latest" -> eventBookmarks=eventBookmarkRepository.findEventsByUserWithLatest(user, category,pageable);
@@ -94,15 +96,17 @@ public class UserService
             errorCodeEnum = TargetRoleErrorCode.class,
             errorCodeName = "TARGET_ROLE_NOT_FOUND"
     )
-    @Transactional(readOnly = true)
+    @Transactional()
     public UserResponse.UserProfileResponse updateUser(Users user, UserRequest.UserUpdateRequest request)
     {
         TargetRole role=targetRoleRepository.findByName(request.getRole()).orElseThrow();
         Set<Interest> interests=interestRepository.findByNameIn(request.getInterests());
         user.update(request,role,interests);
+        userRepository.save(user);
         return userMapper.toUserProfileResponse(user);
     }
 
+    @Transactional(readOnly = true)
     public List<UserResponse.InquiryResponse> getAllInquiry()
     {
         return inquiryRepository.findAll().stream().map(userMapper::toInquiryResponse).toList();


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

getMyPageHome 함수 부분에서 UserDetatils에서 가져온 User가 영속성 컨텍스트가 아니라서 User의 Role를 Lazy하게 가져오는 게 실패하였습니다. 이에 영속성 컨텍스트로 변경하였습니다.


## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
