### PR TITLE
[FEAT] : 프로필 수정에 S3 추가 및 test 코드 수정

### DIFF
--- a/src/main/java/com/example/skillup/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/skillup/domain/user/controller/UserController.java
@@ -11,17 +11,22 @@ import com.example.skillup.global.auth.service.AuthService;
 import com.example.skillup.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor
-public class UserController
-{
+public class UserController {
     private final UserService userService;
     private final AuthService authService;
 
@@ -34,9 +39,9 @@ public class UserController
     }
 
     @GetMapping("/test-login")
-    public BaseResponse<String> testLogin()
-    {
-        return BaseResponse.success("테스트 용 엑세스 토큰입니다(모든 권한 허용)",authService.login("test@example.com", "users").accessToken());
+    public BaseResponse<String> testLogin() {
+        return BaseResponse.success("테스트 용 엑세스 토큰입니다(모든 권한 허용)",
+                authService.login("test@example.com", "users").accessToken());
     }
 
 
@@ -44,13 +49,13 @@ public class UserController
     @Operation(summary = "마이페이지 첫 홈 화면 API로 유저의 이메일과 이름을 리턴합니다."
             , description = "마이페이지 첫 홈 화면 API")
     public BaseResponse<UserResponse.MyPageHomeResponse> getMyPageHome(@AuthenticationPrincipal UsersDetails user) {
-        return BaseResponse.success("마이 페이지 홈 조회 성공",userService.getMyPageHome(user.getUser()));
+        return BaseResponse.success("마이 페이지 홈 조회 성공", userService.getMyPageHome(user.getUser()));
     }
 
     @GetMapping("/my-page/bookmark")
     @Operation(summary = "마이페이지에서 유저가 북마크 한 이벤트 불러옵니다.(sort 값 latest, deadline)"
             , description = "마이페이지 북마크 페이지 API")
-    public  BaseResponse<UserResponse.MyPageBookMarkResponse> getMyPageBookMark(
+    public BaseResponse<UserResponse.MyPageBookMarkResponse> getMyPageBookMark(
             @AuthenticationPrincipal UsersDetails user,
             @Parameter(
                     description = "정렬 기준 (latest, deadline)"
@@ -58,7 +63,8 @@ public class UserController
             @RequestParam String sort,
             @RequestParam int page
     ) {
-        return  BaseResponse.success("마이페이지 북마크된 이벤트 조회 성공",userService.getMyPageBookMark(user.getUser(),sort,page));
+        return BaseResponse.success("마이페이지 북마크된 이벤트 조회 성공",
+                userService.getMyPageBookMark(user.getUser(), sort, page));
     }
 
     @GetMapping("/my-page/profile/interest")
@@ -69,21 +75,20 @@ public class UserController
         return BaseResponse.success("직무별 관심사 조회 성공",userService.getInterestByRole(roleName));
     }
 
-    @PutMapping("/my-page/profile/update")
+    @PutMapping(value = "/my-page/profile/update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "유저 프로필을 업데이트 합니다."
             , description = "유저 프로필 업데이트 API")
     public BaseResponse<UserResponse.UserProfileResponse> updateProfile(
             @AuthenticationPrincipal UsersDetails userDetails,
-            @RequestBody UserRequest.UserUpdateRequest request
+            @RequestPart UserRequest.UserUpdateRequest request,
+            @RequestPart MultipartFile profileImage
     ) {
-        userService.updateUser(userDetails.getUser(), request);
-        return BaseResponse.success("유저 업데이트 성공", userService.updateUser(userDetails.getUser(), request));
+        return BaseResponse.success("유저 업데이트 성공", userService.updateUser(userDetails.getUser(), request, profileImage));
     }
 
     @GetMapping("/my-page/qna")
     @Operation(summary = "마이페이지 고객센터 문의 목록 조회", description = "사용자가 마이페이지에서 등록한 모든 문의 내역을 조회하는 API")
-    public BaseResponse<List<UserResponse.InquiryResponse>> getAllInquiry()
-    {
+    public BaseResponse<List<UserResponse.InquiryResponse>> getAllInquiry() {
         return BaseResponse.success("모든 문의 내용 조회 성공", userService.getAllInquiry());
     }
 

--- a/src/main/java/com/example/skillup/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/request/UserRequest.java
@@ -1,10 +1,9 @@
 package com.example.skillup.domain.user.dto.request;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 public class UserRequest
 {
@@ -13,7 +12,6 @@ public class UserRequest
     @Builder
     public static class UserUpdateRequest {
         private String name;
-        private String profileImageUrl;
         private String age;
         private String gender;
         private String role;

--- a/src/main/java/com/example/skillup/domain/user/entity/Users.java
+++ b/src/main/java/com/example/skillup/domain/user/entity/Users.java
@@ -1,22 +1,33 @@
 package com.example.skillup.domain.user.entity;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import com.example.skillup.domain.event.entity.TargetRole;
 import com.example.skillup.domain.oauth.Entity.SocialLoginType;
 import com.example.skillup.domain.user.dto.request.UserRequest;
 import com.example.skillup.domain.user.enums.UserStatus;
 import com.example.skillup.global.common.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
-
-import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
-
-import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
@@ -78,9 +89,9 @@ public class Users extends BaseEntity
 
     private boolean marketingAgreement;
 
-    public void update(UserRequest.UserUpdateRequest dto,TargetRole role,Set<Interest> interests) {
+    public void update(UserRequest.UserUpdateRequest dto,TargetRole role,Set<Interest> interests , String userProfileImageUrl) {
         if (dto.getName() != null) this.name = dto.getName();
-        if (dto.getProfileImageUrl() != null) this.profileImageUrl = dto.getProfileImageUrl();
+        if (userProfileImageUrl != null) this.profileImageUrl = userProfileImageUrl;
         if (dto.getAge() != null) this.age = dto.getAge();
         if (dto.getMarketingAgreement() != null) this.marketingAgreement = dto.getMarketingAgreement();
         if (dto.getGender() != null) this.gender = dto.getGender();

--- a/src/main/java/com/example/skillup/domain/user/service/UserService.java
+++ b/src/main/java/com/example/skillup/domain/user/service/UserService.java
@@ -4,7 +4,6 @@ package com.example.skillup.domain.user.service;
 import com.example.skillup.domain.event.dto.response.EventResponse;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.TargetRole;
-import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.exception.EventException;
 import com.example.skillup.domain.event.exception.TargetRoleErrorCode;
 import com.example.skillup.domain.event.mapper.EventMapper;
@@ -14,29 +13,28 @@ import com.example.skillup.domain.user.dto.request.UserRequest;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Interest;
 import com.example.skillup.domain.user.entity.Users;
-import com.example.skillup.domain.user.entity.UsersDetails;
 import com.example.skillup.domain.user.mappers.UserMapper;
 import com.example.skillup.domain.user.repository.InquiryRepository;
 import com.example.skillup.domain.user.repository.InterestRepository;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.aop.ConvertNotFound;
 import com.example.skillup.global.common.CommonResponse;
+import com.example.skillup.global.service.S3Service;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class UserService
-{
+public class UserService {
     final private UserMapper userMapper;
     final private EventBookmarkRepository eventBookmarkRepository;
     final private InterestRepository interestRepository;
@@ -44,54 +42,53 @@ public class UserService
     final private TargetRoleRepository targetRoleRepository;
     final private InquiryRepository inquiryRepository;
     private final UserRepository userRepository;
+    private final S3Service s3Service;
 
-    public UserResponse.MyPageHomeResponse getMyPageHome(Users user)
-    {
+    public UserResponse.MyPageHomeResponse getMyPageHome(Users user) {
         return userMapper.toMyPageHomeResponse(user);
     }
 
     @Transactional(readOnly = true)
-    public UserResponse.MyPageBookMarkResponse getMyPageBookMark(Users user,String sort,int page)
-    {
-        List<Event> eventBookmarks=new ArrayList<>();
+    public UserResponse.MyPageBookMarkResponse getMyPageBookMark(Users user, String sort, int page) {
+        List<Event> eventBookmarks = new ArrayList<>();
         Pageable pageable = PageRequest.of(page, 9);
 
         //user를 영속성 컨텍스트로 만들기 위해서
-        user=userRepository.findById(user.getId()).orElse(null);
+        user = userRepository.findById(user.getId()).orElse(null);
 
         switch (sort) {
-            case "latest" -> eventBookmarks=eventBookmarkRepository.findEventsByUserWithLatest(user, pageable);
-            case "deadline" -> eventBookmarks=eventBookmarkRepository.findEventsByUserWithDeadLine(user, pageable);
+            case "latest" -> eventBookmarks = eventBookmarkRepository.findEventsByUserWithLatest(user, pageable);
+            case "deadline" -> eventBookmarks = eventBookmarkRepository.findEventsByUserWithDeadLine(user, pageable);
         }
-        List<EventResponse.HomeEventResponse> eventBookmarksDto=eventBookmarks.stream()
+        List<EventResponse.HomeEventResponse> eventBookmarksDto = eventBookmarks.stream()
                 .map(event -> eventMapper.toFeaturedEvent(event, true, event.isRecommendedManual(), event.isAd(), null))
                 .toList();
 
         CommonResponse.PageInfoResponse pageInfoResponse = CommonResponse.PageInfoResponse
                 .builder()
-                .currentPage(page+1)
+                .currentPage(page + 1)
                 .pageSize(pageable.getPageSize())
                 .totalPages((int) Math.ceil((double) eventBookmarksDto.size() / (pageable.getPageSize())))
                 .build();
 
-        List<EventResponse.HomeEventResponse> recruitingEvents=new ArrayList<>();
-        List<EventResponse.HomeEventResponse> closedEvents=new ArrayList<>();
+        List<EventResponse.HomeEventResponse> recruitingEvents = new ArrayList<>();
+        List<EventResponse.HomeEventResponse> closedEvents = new ArrayList<>();
 
-        for(EventResponse.HomeEventResponse event:eventBookmarksDto)
-        {
-            if (event.getD_dayLabel().equals("마감"))
+        for (EventResponse.HomeEventResponse event : eventBookmarksDto) {
+            if (event.getD_dayLabel().equals("마감")) {
                 closedEvents.add(event);
-            else
+            } else {
                 recruitingEvents.add(event);
+            }
         }
-        return userMapper.toMyPageBookMarkResponse(user,recruitingEvents,closedEvents,pageInfoResponse);
+        return userMapper.toMyPageBookMarkResponse(user, recruitingEvents, closedEvents, pageInfoResponse);
     }
 
     @Transactional(readOnly = true)
-    public List<UserResponse.InterestResponse> getInterestByRole(String roleName)
-    {
-        Optional<TargetRole> targetRole=targetRoleRepository.findByName(roleName);
-        return interestRepository.findByRole(targetRole.orElseThrow()).stream().map(userMapper::toInterestResponse).toList();
+    public List<UserResponse.InterestResponse> getInterestByRole(String roleName) {
+        Optional<TargetRole> targetRole = targetRoleRepository.findByName(roleName);
+        return interestRepository.findByRole(targetRole.orElseThrow()).stream().map(userMapper::toInterestResponse)
+                .toList();
     }
 
     @ConvertNotFound(
@@ -99,24 +96,23 @@ public class UserService
             errorCodeEnum = TargetRoleErrorCode.class,
             errorCodeName = "TARGET_ROLE_NOT_FOUND"
     )
-    @Transactional()
-    public UserResponse.UserProfileResponse updateUser(Users user, UserRequest.UserUpdateRequest request)
-    {
-        TargetRole role=targetRoleRepository.findByName(request.getRole()).orElseThrow();
-        Set<Interest> interests=interestRepository.findByNameIn(request.getInterests());
-        user.update(request,role,interests);
-        userRepository.save(user);
+    @Transactional
+    public UserResponse.UserProfileResponse updateUser(Users user, UserRequest.UserUpdateRequest request,
+                                                       MultipartFile profileImage) {
+        TargetRole role = targetRoleRepository.findByName(request.getRole()).orElseThrow();
+        Set<Interest> interests = interestRepository.findByNameIn(request.getInterests());
+        String userProfileImageUrl = s3Service.uploadFile(profileImage, "user/profile");
+        user.update(request, role, interests, userProfileImageUrl);
         return userMapper.toUserProfileResponse(user);
     }
 
     @Transactional(readOnly = true)
-    public List<UserResponse.InquiryResponse> getAllInquiry()
-    {
+    public List<UserResponse.InquiryResponse> getAllInquiry() {
         return inquiryRepository.findAllByOrderByIdAsc().stream().map(userMapper::toInquiryResponse).toList();
     }
 
     public UserResponse.UserProfileResponse getUsers(Users user) {
-        user=userRepository.findById(user.getId()).orElse(null);
+        user = userRepository.findById(user.getId()).orElse(null);
         return userMapper.toUserProfileResponse(user);
     }
 }

--- a/src/test/java/com/example/skillup/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/user/service/UserServiceTest.java
@@ -1,6 +1,12 @@
 package com.example.skillup.domain.user.service;
 
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventBookmark;
 import com.example.skillup.domain.event.entity.TargetRole;
@@ -18,24 +24,24 @@ import com.example.skillup.domain.user.enums.UserStatus;
 import com.example.skillup.domain.user.repository.InterestRepository;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.common.BaseEntity;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-
+import com.example.skillup.global.service.S3Service;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class UserServiceTest
-{
+public class UserServiceTest {
     @Autowired
     private UserService userService;
 
@@ -54,13 +60,17 @@ public class UserServiceTest
     @Autowired
     private EventBookmarkRepository eventBookmarkRepository;
 
+    @MockitoBean
+    private S3Service s3Service;
+
     private Users u1;
     private TargetRole role;
+
     @BeforeEach
     void setUp() {
         targetRoleRepository.deleteAll();
         userRepository.deleteAll();
-        role =targetRoleRepository.save(TargetRole.builder().name("PLANNER").build());
+        role = targetRoleRepository.save(TargetRole.builder().name("PLANNER").build());
         targetRoleRepository.save(TargetRole.builder().name("DESIGNER").build());
         targetRoleRepository.save(TargetRole.builder().name("AI_DEVELOPER").build());
         u1 = userRepository.save(
@@ -82,9 +92,8 @@ public class UserServiceTest
     }
 
     @Test
-    public void getMyPageHome_Success()
-    {
-        UserResponse.MyPageHomeResponse response=userService.getMyPageHome(u1);
+    public void getMyPageHome_Success() {
+        UserResponse.MyPageHomeResponse response = userService.getMyPageHome(u1);
         assertThat(u1.getEmail()).isEqualTo(response.getEmail());
         assertThat(u1.getName()).isEqualTo(response.getName());
 
@@ -144,9 +153,9 @@ public class UserServiceTest
                 .eventEnd(LocalDateTime.now().plusDays(200))
                 .build();
 
-        eventRepository.saveAll(List.of(event1, event2, event3,event4));
+        eventRepository.saveAll(List.of(event1, event2, event3, event4));
 
-        EventBookmark oldEventBookmark =EventBookmark.builder().event(event2).user(u1).build();
+        EventBookmark oldEventBookmark = EventBookmark.builder().event(event2).user(u1).build();
         createdField.set(oldEventBookmark, LocalDate.now().minusMonths(5).atStartOfDay());
 
         eventBookmarkRepository.save(oldEventBookmark);
@@ -172,19 +181,28 @@ public class UserServiceTest
         assertThat(event2.getId()).isEqualTo(response2.getRecruitingEvents().get(2).getId());
 
 
-
-
     }
 
     @Test
-    public void updateUser_Success()
-    {
+    public void updateUser_Success() {
         interestRepository.save(Interest.builder().role(role).name("코딩").build());
-        UserRequest.UserUpdateRequest request=UserRequest.UserUpdateRequest.builder().age("22").name("김").profileImageUrl("www")
+        UserRequest.UserUpdateRequest request = UserRequest.UserUpdateRequest.builder().age("22").name("김")
                 .gender("남").role("AI_DEVELOPER").interests(List.of("코딩")).build();
-        UserResponse.UserProfileResponse response=userService.updateUser(u1,request);
 
-        assertThat(response.getProfileImageUrl()).isEqualTo("www");
+        MultipartFile profileImage = new MockMultipartFile(
+                "profileImage",
+                "test-profile.jpg",
+                "image/jpeg",
+                "test image bytes".getBytes()
+        );
+
+        when(s3Service.uploadFile(any(MultipartFile.class), anyString())).thenReturn("test-profile.jpg");
+
+        UserResponse.UserProfileResponse response = userService.updateUser(u1, request, profileImage);
+
+        verify(s3Service).uploadFile(any(MultipartFile.class), anyString());
+
+        assertThat(response.getProfileImageUrl()).endsWith("test-profile.jpg");
         assertThat(response.getAge()).isEqualTo("22");
         assertThat(response.getRole()).isEqualTo("AI_DEVELOPER");
         assertThat(response.getGender()).isEqualTo("남");


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

프로필 수정 API에 S3 업로드 로직을 추가하고, 이에 맞춰 도메인/요청 DTO/테스트 코드를 정리했습니다.  
실제 S3를 호출하지 않도록 테스트에서는 `S3Service`를 목으로 주입하여 파일 업로드 흐름만 검증하게 구성했습니다.

## 1. 프로필 수정 API S3 연동

### 1-1. 컨트롤러 & 요청 형태 변경
- `@RequestBody` → `@RequestPart`로 수정하여 **JSON + 파일 업로드를 동시에 처리**하도록 변경
- `profileImage` `MultipartFile` 파라미터 추가
- `UserUpdateRequest`에서 `imageUrl` 필드 제거  

### 1-2. 서비스 & 도메인 변경
- `UserService.updateUser(...)`에서
  - `profileImage`가 존재할 경우 `S3Service.uploadFile(...)` 호출
  - 반환된 URL을 `Users.update()`에 전달하여 `userProfileImageUrl` 필드 업데이트
- `Users.update(...)`에 `userProfileImageUrl` 갱신 로직 추가  

---

## 2. UserServiceTest 리팩터링 및 S3 연동 테스트 추가

### 2-1. S3 의존성 목 처리
- `@MockitoBean`으로 `S3Service`를 목으로 주입
- 실제 S3에 업로드하지 않고, 테스트 내에서 업로드 결과를 반환

### 2-2. 프로필 수정 테스트 강화 (`updateUser_Success`)

- `MockMultipartFile`로 `profileImage` 업로드 상황 시뮬레이션
- `userService.updateUser(u1, request, profileImage)` 호출을 통해 실제 흐름 검증
- `S3Service` 연동 검증
  - `verify(s3Service).uploadFile(any(MultipartFile.class), anyString())` 로 S3 업로드 메서드 호출 여부 확인
- 응답 값 검증
  - `assertThat(response.getProfileImageUrl()).endsWith("test-profile.jpg");`
  - → 응답의 `profileImageUrl`이 S3 업로드 결과(URL)의 파일명을 반영하는지 확인
  - **S3 업로드 결과로만 세팅되도록 테스트 로직도 함께 정렬**

### 2-3. 기타 테스트 코드 정리

- 사용되지 않거나 중복된 `import` 정리
- 코드 포맷/컨벤션 통일 (`{` 위치, 공백, 변수명 스타일 등)

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
