### PR TITLE
[FEAT] banner 생성/수정/삭제 api 추가 및 banner service 로직 분리

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -156,13 +156,24 @@ public class EventController {
         return BaseResponse.success("카테고리별 리스트 조회 성공", eventService.getEventsByCategoryForHome(category, page, size));
     }
 
-    @GetMapping("/home/banners")
-    @Operation(summary = "메인 배너 및 서브 배너 리스트", description = "메인 배너 순서대로 정렬 , 서브배너는 설정해둔 하나만 반환합니다.")
-    public BaseResponse<EventResponse.EventBannersResponseList> getHomeBanners() {
-        return BaseResponse.success("배너 리스트 조회 성공", eventBannerService.getEventBanners());
+    @GetMapping("/home/admin/banners")
+    //@PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "관리자용 배너 리스트 API 입니다.", description = "관리자용 배너 조회 API 입니다. 현재 배너 + 이전 배너 를 반환합니다. page 값은 1부터 넣어주세요(이전 배너용 페이지)")
+    public BaseResponse<EventResponse.EventBannerAdminResponse> getBannersAll(
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        return BaseResponse.success("배너 리스트 조회 성공", eventBannerService.getEventBanners(page));
     }
 
-    @PostMapping(value = "/home/banners", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @GetMapping("/home/banners")
+    //@PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "메인 페이지에 나올 배너 조회 API 입니다.", description = "현재 날짜가 배너의 노출일과 마감일 사이에 있는 배너를 반환합니다.")
+    public BaseResponse<EventResponse.EventBannersResponseList> getHomeBanners(
+    ) {
+        return BaseResponse.success("배너 리스트 조회 성공", eventBannerService.getActiveEventBanners());
+    }
+
+    @PostMapping(value = "/home/admin/banners", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     //@PreAuthorize("hasRole('OWNER')")
     @Operation(summary = "배너 등록 API", description = "배너 등록 API 입니다. / 배너타입은 MAIN_BANNER 또는 SUB_BANNER 입니다.")
     public BaseResponse<EventResponse.EventBannerResponse> createHomeBanners(
@@ -204,8 +215,8 @@ public class EventController {
     @Operation(summary = "배너 삭제 API", description = "지우실 배너 아이디를 입력해주세요")
     public BaseResponse<EventResponse.CommonBannerResponse> deleteHomeBanner(
             @PathVariable Long bannerId
-    ){
-        return BaseResponse.success("배너 삭제 성공" , eventBannerService.deleteBanner(bannerId));
+    ) {
+        return BaseResponse.success("배너 삭제 성공", eventBannerService.deleteBanner(bannerId));
     }
 
     @PostMapping("category-page/search")

--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -7,6 +7,7 @@ import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventBookmark;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventStatus;
+import com.example.skillup.domain.event.service.EventBannerService;
 import com.example.skillup.domain.event.service.EventBookmarkService;
 import com.example.skillup.domain.event.service.EventService;
 import com.example.skillup.domain.user.entity.UsersDetails;
@@ -45,6 +46,7 @@ public class EventController {
     private final EventService eventService;
     private final EventSearchService eventSearchService;
     private final EventBookmarkService eventBookmarkService;
+    private final EventBannerService eventBannerService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     //@PreAuthorize("hasRole('OWNER')")
@@ -157,7 +159,43 @@ public class EventController {
     @GetMapping("/home/banners")
     @Operation(summary = "메인 배너 및 서브 배너 리스트", description = "메인 배너 순서대로 정렬 , 서브배너는 설정해둔 하나만 반환합니다.")
     public BaseResponse<EventResponse.EventBannersResponseList> getHomeBanners() {
-        return BaseResponse.success("배너 리스트 조회 성공", eventService.getEventBanners());
+        return BaseResponse.success("배너 리스트 조회 성공", eventBannerService.getEventBanners());
+    }
+
+    @PostMapping(value = "/home/banners", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    //@PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "배너 등록 API", description = "배너 등록 API 입니다. / 배너타입은 MAIN_BANNER 또는 SUB_BANNER 입니다.")
+    public BaseResponse<EventResponse.EventBannerResponse> createHomeBanners(
+            @RequestPart @Valid EventRequest.CreateEventBannerRequest request,
+            @RequestPart("bannerImage") MultipartFile bannerImage) {
+        return BaseResponse.success("배너 등록 성공", eventBannerService.createBanner(bannerImage, request));
+    }
+
+    @PutMapping(value = "/home/banners/{bannerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    //@PreAuthorize("hasRole('OWNER')")
+    @Operation(
+            summary = "배너 수정 API",
+            description = """
+                    배너 수정 API 입니다.
+                    - 배너 타입: MAIN_BANNER 또는 SUB_BANNER
+                    - 이미지 파일(profileImage)은 선택적으로 전송 가능합니다.
+                    """
+    )
+    public BaseResponse<EventResponse.EventBannerResponse> updateHomeBanner(
+            @PathVariable Long bannerId,
+            @RequestPart @Valid EventRequest.UpdateEventBannerRequest request,
+            @RequestPart(name = "bannerImage", required = false) MultipartFile bannerImage
+    ) {
+        return BaseResponse.success("배너 수정 성공", eventBannerService.updateBanner(bannerId, request, bannerImage));
+    }
+
+    @DeleteMapping("/home/banners/{bannerId}")
+    //@PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "배너 삭제 API", description = "지우실 배너 아이디를 입력해주세요")
+    public BaseResponse<EventResponse.CommonBannerResponse> deleteHomeBanner(
+            @PathVariable Long bannerId
+    ){
+        return BaseResponse.success("배너 삭제 성공" , eventBannerService.deleteBanner(bannerId));
     }
 
     @PostMapping("category-page/search")

--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -171,7 +171,17 @@ public class EventController {
         return BaseResponse.success("배너 등록 성공", eventBannerService.createBanner(bannerImage, request));
     }
 
-    @PutMapping(value = "/home/banners/{bannerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping("/home/admin/banners/order")
+    //@PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "배너 순서 정렬 API", description = "정렬된 상태의 배너의 ID 값을 순서대로 보내주세요 앞에 오는게 우선순위가 높습니다.")
+    public BaseResponse<Void> updateDisplayOrderHomeBanners(
+            @RequestBody @Valid EventRequest.BannerOrderUpdateRequest request
+    ) {
+        eventBannerService.updateBannerOrder(request.getBannerIds());
+        return BaseResponse.success("배너 순서 수정 성공" ,null);
+    }
+
+    @PutMapping(value = "/home/admin/banners/{bannerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     //@PreAuthorize("hasRole('OWNER')")
     @Operation(
             summary = "배너 수정 API",

--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -1,6 +1,5 @@
 package com.example.skillup.domain.event.dto.request;
 
-import com.example.skillup.domain.event.enums.BannerType;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventFormat;
 import com.example.skillup.domain.event.enums.EventSortType;
@@ -204,18 +203,12 @@ public class EventRequest {
         public boolean isValidPeriod() {
             return !bannerEnd.isBefore(bannerStart);
         }
-
-        @NotNull(message = "입력값은 MAIN_BANNER 또는 SUB_BANNER 로 입력해주세요")
-        BannerType bannerType;
     }
 
     @Getter
     @Builder
     @AllArgsConstructor
     public static class UpdateEventBannerRequest {
-
-        @NotNull(message = "입력값은 MAIN_BANNER 또는 SUB_BANNER 로 입력해주세요")
-        private BannerType bannerType;
 
         @NotBlank(message = "배너명을 입력해주세요")
         @Size(max = 100)

--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -1,11 +1,16 @@
 package com.example.skillup.domain.event.dto.request;
 
+import com.example.skillup.domain.event.enums.BannerType;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventFormat;
 import com.example.skillup.domain.event.enums.EventSortType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -69,7 +74,6 @@ public class EventRequest {
 
     @Getter
     @AllArgsConstructor
-
     public static class UpdateEvent {
         @NotNull(message = "제목을 입력해주세요.")
         private String title;
@@ -174,6 +178,63 @@ public class EventRequest {
         @NotNull(message = "페이지 번호를 입력해주세요. (페이지당 게시글은 12개)")
         private Integer page = 0;
 
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CreateEventBannerRequest {
+
+        @NotBlank(message = "배너명을 입력해주세요")
+        @Size(max = 100)
+        private String title;
+
+        @NotNull(message = "배너 클릭시 이동 할 링크를 입력해주세요")
+        private String bannerLink;
+
+        @NotNull(message = "배너 노출 시작일을 입력해주세요")
+        @FutureOrPresent(message = "배너 노출 시작일은 오늘 이전일 수 없습니다.")
+        LocalDate bannerStart;
+
+        @NotNull(message = "배너 노출 마감일을 입력해주세요")
+        LocalDate bannerEnd;
+
+        @AssertTrue(message = "배너 종료일은 시작일보다 빠를 수 없습니다.")
+        @JsonIgnore
+        public boolean isValidPeriod() {
+            return !bannerEnd.isBefore(bannerStart);
+        }
+
+        @NotNull(message = "입력값은 MAIN_BANNER 또는 SUB_BANNER 로 입력해주세요")
+        BannerType bannerType;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class UpdateEventBannerRequest {
+
+        @NotNull(message = "입력값은 MAIN_BANNER 또는 SUB_BANNER 로 입력해주세요")
+        private BannerType bannerType;
+
+        @NotBlank(message = "배너명을 입력해주세요")
+        @Size(max = 100)
+        private String title;
+
+        @NotNull
+        private String bannerLink;
+
+        @NotNull(message = "배너 노출 시작일은 필수입니다.")
+        @FutureOrPresent
+        private LocalDate bannerStart;
+
+        private LocalDate bannerEnd;
+
+        @AssertTrue(message = "배너 종료일은 시작일보다 빠를 수 없습니다.")
+        @JsonIgnore
+        public boolean isValidPeriod() {
+            return !bannerEnd.isBefore(bannerStart);
+        }
     }
 
 }

--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
@@ -228,6 +229,13 @@ public class EventRequest {
         public boolean isValidPeriod() {
             return !bannerEnd.isBefore(bannerStart);
         }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class BannerOrderUpdateRequest{
+        @NotEmpty List<Long> bannerIds;
     }
 
 }

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -154,15 +154,13 @@ public class EventResponse {
     @AllArgsConstructor
     public static class EventBannersResponseList {
         private List<EventBannerResponse> eventMainBannerReponseList;
-        private List<EventBannerResponse> eventSubBannerResponse;
     }
-
 
 
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class EventApplyResponse{
+    public static class EventApplyResponse {
         private Long eventId;
         private String comment;
 

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -2,12 +2,13 @@ package com.example.skillup.domain.event.dto.response;
 
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventStatus;
+import com.example.skillup.global.common.CommonResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
-import com.example.skillup.global.common.CommonResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,12 @@ public class EventResponse {
     @AllArgsConstructor
     public static class CommonEventResponse {
         private Long eventId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CommonBannerResponse {
+        private Long bannerId;
     }
 
     @Getter
@@ -129,14 +136,16 @@ public class EventResponse {
 
     @Getter
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class EventBannerResponse {
         private int displayOrder;
 
         private String title;
         private String bannerImageUrl;
         private String bannerLink;
-        private LocalDateTime StartAt;
-        private LocalDateTime EndAt;
+        private String bannerType;
+        private LocalDate StartAt;
+        private LocalDate EndAt;
 
     }
 

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -156,6 +156,14 @@ public class EventResponse {
         private List<EventBannerResponse> eventMainBannerReponseList;
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class EventBannerAdminResponse{
+        private List<EventBannerResponse> eventActiveBannerList;
+        private List<EventBannerResponse> eventPastBannerList;
+    }
+
 
     @Getter
     @Builder

--- a/src/main/java/com/example/skillup/domain/event/entity/EventBanner.java
+++ b/src/main/java/com/example/skillup/domain/event/entity/EventBanner.java
@@ -62,9 +62,6 @@ public class EventBanner extends BaseEntity {
 
 
     public void updateInfo(EventRequest.UpdateEventBannerRequest request) {
-        if (request.getBannerType() != null) {
-            this.type = request.getBannerType();
-        }
         if (request.getTitle() != null) {
             this.title = request.getTitle();
         }

--- a/src/main/java/com/example/skillup/domain/event/entity/EventBanner.java
+++ b/src/main/java/com/example/skillup/domain/event/entity/EventBanner.java
@@ -79,4 +79,8 @@ public class EventBanner extends BaseEntity {
     public void updateBannerImage(String newBannerImageUrl) {
         this.bannerImageUrl = newBannerImageUrl;
     }
+
+    public void updateBannerOrder(int displayOrder){
+        this.displayOrder = displayOrder;
+    }
 }

--- a/src/main/java/com/example/skillup/domain/event/entity/EventBanner.java
+++ b/src/main/java/com/example/skillup/domain/event/entity/EventBanner.java
@@ -1,19 +1,24 @@
 package com.example.skillup.domain.event.entity;
 
 
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.enums.BannerType;
 import com.example.skillup.global.common.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
-
-import java.time.LocalDateTime;
-
-import static jakarta.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
@@ -38,7 +43,8 @@ public class EventBanner extends BaseEntity {
     private String title;
 
     @Column(nullable = false)
-    private boolean selected = false;
+    @Builder.Default
+    private boolean selected = true;
 
     @Column
     private String bannerLink;
@@ -49,8 +55,31 @@ public class EventBanner extends BaseEntity {
 
     //노출 시작/종료
     @Column(nullable = false)
-    private LocalDateTime startAt;
+    private LocalDate startAt;
 
     @Column
-    private LocalDateTime endAt; //null 이면 무기한
+    private LocalDate endAt; //null 이면 무기한
+
+
+    public void updateInfo(EventRequest.UpdateEventBannerRequest request) {
+        if (request.getBannerType() != null) {
+            this.type = request.getBannerType();
+        }
+        if (request.getTitle() != null) {
+            this.title = request.getTitle();
+        }
+        if (request.getBannerLink() != null) {
+            this.bannerLink = request.getBannerLink();
+        }
+        if (request.getBannerStart() != null) {
+            this.startAt = request.getBannerStart();
+        }
+        if (request.getBannerEnd() != null) {
+            this.endAt = request.getBannerEnd();
+        }
+    }
+
+    public void updateBannerImage(String newBannerImageUrl) {
+        this.bannerImageUrl = newBannerImageUrl;
+    }
 }

--- a/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
@@ -16,7 +16,8 @@ public enum EventErrorCode implements ResultCode {
     EVENT_SEARCH_QUERY_TOO_SHORT("EVENT_SEARCH_QUERY_TOO_SHORT", "검색어는 2글자 이상 입력해 주세요.", HttpStatus.BAD_REQUEST),
     EVENT_INCORRECT_USER("EVENT_INCORRECT_USER", "해당 기능에 올바른 사용자가 아닙니다.", HttpStatus.BAD_REQUEST),
     EVENT_SEARCH_ERROR("EVENT_SEARCH_ERROR", "검색 기능 시 에러가 발생했습니다.", HttpStatus.BAD_REQUEST),
-    BANNER_ENTITY_NOT_FOUND("BANNER_ENTITY_NOT_FOUND", "배너가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+    BANNER_ENTITY_NOT_FOUND("BANNER_ENTITY_NOT_FOUND", "배너가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    INVALID_BANNER_ID("INVALID_BANNER_ID" , "잘못된 배너 아이디입니다." , HttpStatus.BAD_REQUEST),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
@@ -8,14 +8,15 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum EventErrorCode implements ResultCode {
-    EVENT_ENTITY_NOT_FOUND("EVENT_ENTITY_NOT_FOUND","행사가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    EVENT_ENTITY_NOT_FOUND("EVENT_ENTITY_NOT_FOUND", "행사가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     EVENT_ALREADY_HIDDEN("EVENT_ALREADY_HIDDEN", "이미 숨김된 행사입니다.", HttpStatus.BAD_REQUEST),
-    EVENT_ALREADY_PUBLISHED("EVENT_ALREADY_PUBLISHED","이미 등록된 행사입니다." ,HttpStatus.BAD_REQUEST),
+    EVENT_ALREADY_PUBLISHED("EVENT_ALREADY_PUBLISHED", "이미 등록된 행사입니다.", HttpStatus.BAD_REQUEST),
     EVENT_ALREADY_DELETED("EVENT_ALREADY_DELETED", "이미 삭제된 행사입니다.", HttpStatus.BAD_REQUEST),
-    EVENT_INDEXING_ERROR("EVENT_INDEXING_ERROR" , "행사 데이터를 인덱싱 처리 과정에서의 에러가 발생했습니다." , HttpStatus.SERVICE_UNAVAILABLE),
+    EVENT_INDEXING_ERROR("EVENT_INDEXING_ERROR", "행사 데이터를 인덱싱 처리 과정에서의 에러가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
     EVENT_SEARCH_QUERY_TOO_SHORT("EVENT_SEARCH_QUERY_TOO_SHORT", "검색어는 2글자 이상 입력해 주세요.", HttpStatus.BAD_REQUEST),
-    EVENT_INCORRECT_USER("EVENT_INCORRECT_USER" , "해당 기능에 올바른 사용자가 아닙니다." , HttpStatus.BAD_REQUEST),
-    EVENT_SEARCH_ERROR("EVENT_SEARCH_ERROR" , "검색 기능 시 에러가 발생했습니다." , HttpStatus.BAD_REQUEST);
+    EVENT_INCORRECT_USER("EVENT_INCORRECT_USER", "해당 기능에 올바른 사용자가 아닙니다.", HttpStatus.BAD_REQUEST),
+    EVENT_SEARCH_ERROR("EVENT_SEARCH_ERROR", "검색 기능 시 에러가 발생했습니다.", HttpStatus.BAD_REQUEST),
+    BANNER_ENTITY_NOT_FOUND("BANNER_ENTITY_NOT_FOUND", "배너가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/example/skillup/domain/event/mapper/BannerMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/BannerMapper.java
@@ -1,0 +1,52 @@
+package com.example.skillup.domain.event.mapper;
+
+import com.example.skillup.domain.event.dto.request.EventRequest;
+import com.example.skillup.domain.event.dto.response.EventResponse;
+import com.example.skillup.domain.event.dto.response.EventResponse.EventBannerResponse;
+import com.example.skillup.domain.event.entity.EventBanner;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BannerMapper {
+    public EventResponse.EventBannersResponseList toEventBannersResponseList(
+            List<EventBannerResponse> mainBanner, List<EventResponse.EventBannerResponse> subBanner) {
+        return new EventResponse.EventBannersResponseList(mainBanner, subBanner);
+    }
+
+    public List<EventResponse.EventBannerResponse> toEventBannerResponse(List<EventBanner> eventBanners) {
+        return eventBanners.stream().map(eventBanner -> EventResponse.EventBannerResponse.builder()
+                .title(eventBanner.getTitle())
+                .bannerImageUrl(eventBanner.getBannerImageUrl())
+                .bannerLink(eventBanner.getBannerLink())
+                .displayOrder(eventBanner.getDisplayOrder())
+                .StartAt(eventBanner.getStartAt())
+                .EndAt(eventBanner.getEndAt())
+                .build()).toList();
+    }
+
+    public EventResponse.EventBannerResponse toCreateBannerResponse(EventBanner eventBanner) {
+        return EventResponse.EventBannerResponse.builder()
+                .title(eventBanner.getTitle())
+                .bannerImageUrl(eventBanner.getBannerImageUrl())
+                .bannerLink(eventBanner.getBannerLink())
+                .displayOrder(eventBanner.getDisplayOrder())
+                .StartAt(eventBanner.getStartAt())
+                .EndAt(eventBanner.getEndAt())
+                .bannerType(eventBanner.getType().toString())
+                .build();
+    }
+
+    public EventBanner toEventBanner(EventRequest.CreateEventBannerRequest request , int displayOrder , String BannerImageUrl) {
+        return EventBanner.builder()
+                .title(request.getTitle())
+                .bannerLink(request.getBannerLink())
+                .displayOrder(displayOrder)
+                .type(request.getBannerType())
+                .startAt(request.getBannerStart())
+                .endAt(request.getBannerEnd())
+                .bannerImageUrl(BannerImageUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/skillup/domain/event/mapper/BannerMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/BannerMapper.java
@@ -15,6 +15,13 @@ public class BannerMapper {
         return new EventResponse.EventBannersResponseList(mainBanner);
     }
 
+    public EventResponse.EventBannerAdminResponse toEventBannerAdminResponse(
+            List<EventBannerResponse> mainBanner , List<EventBannerResponse> pastBanner
+    ){
+        return new EventResponse.EventBannerAdminResponse(mainBanner,pastBanner);
+    }
+
+
     public List<EventResponse.EventBannerResponse> toEventBannerResponse(List<EventBanner> eventBanners) {
         return eventBanners.stream().map(eventBanner -> EventResponse.EventBannerResponse.builder()
                 .title(eventBanner.getTitle())

--- a/src/main/java/com/example/skillup/domain/event/mapper/BannerMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/BannerMapper.java
@@ -4,14 +4,15 @@ import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.dto.response.EventResponse;
 import com.example.skillup.domain.event.dto.response.EventResponse.EventBannerResponse;
 import com.example.skillup.domain.event.entity.EventBanner;
+import com.example.skillup.domain.event.enums.BannerType;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BannerMapper {
     public EventResponse.EventBannersResponseList toEventBannersResponseList(
-            List<EventBannerResponse> mainBanner, List<EventResponse.EventBannerResponse> subBanner) {
-        return new EventResponse.EventBannersResponseList(mainBanner, subBanner);
+            List<EventBannerResponse> mainBanner) {
+        return new EventResponse.EventBannersResponseList(mainBanner);
     }
 
     public List<EventResponse.EventBannerResponse> toEventBannerResponse(List<EventBanner> eventBanners) {
@@ -37,12 +38,13 @@ public class BannerMapper {
                 .build();
     }
 
-    public EventBanner toEventBanner(EventRequest.CreateEventBannerRequest request , int displayOrder , String BannerImageUrl) {
+    public EventBanner toEventBanner(EventRequest.CreateEventBannerRequest request, int displayOrder,
+                                     String BannerImageUrl) {
         return EventBanner.builder()
                 .title(request.getTitle())
                 .bannerLink(request.getBannerLink())
                 .displayOrder(displayOrder)
-                .type(request.getBannerType())
+                .type(BannerType.MAIN_BANNER)
                 .startAt(request.getBannerStart())
                 .endAt(request.getBannerEnd())
                 .bannerImageUrl(BannerImageUrl)

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -3,7 +3,6 @@ package com.example.skillup.domain.event.mapper;
 import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.dto.response.EventResponse;
 import com.example.skillup.domain.event.entity.Event;
-import com.example.skillup.domain.event.entity.EventBanner;
 import com.example.skillup.domain.event.entity.HashTag;
 import com.example.skillup.domain.event.entity.TargetRole;
 import com.example.skillup.domain.event.enums.EventCategory;
@@ -119,22 +118,6 @@ public class EventMapper {
                 .category(category)
                 .homeEventResponseList(events)
                 .build();
-    }
-
-    public EventResponse.EventBannersResponseList toEventBannersResponseList(
-            List<EventResponse.EventBannerResponse> mainBanner, List<EventResponse.EventBannerResponse> subBanner) {
-        return new EventResponse.EventBannersResponseList(mainBanner, subBanner);
-    }
-
-    public List<EventResponse.EventBannerResponse> toEventBannerResponse(List<EventBanner> eventBanners) {
-        return eventBanners.stream().map(eventBanner -> EventResponse.EventBannerResponse.builder()
-                .title(eventBanner.getTitle())
-                .bannerImageUrl(eventBanner.getBannerImageUrl())
-                .bannerLink(eventBanner.getBannerLink())
-                .displayOrder(eventBanner.getDisplayOrder())
-                .StartAt(eventBanner.getStartAt())
-                .EndAt(eventBanner.getEndAt())
-                .build()).toList();
     }
 
     public EventResponse.HomeEventResponse mapEsDocToHomeItem(

--- a/src/main/java/com/example/skillup/domain/event/repository/EventBannerRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventBannerRepository.java
@@ -22,4 +22,6 @@ public interface EventBannerRepository extends JpaRepository<EventBanner, Long> 
     List<EventBanner> findActiveEventBannersByType(@Param("bannerType") BannerType bannerType, @Param("now")LocalDateTime now, Pageable pageable);
 
     Optional<EventBanner> findTopByTypeOrderByDisplayOrderDesc(BannerType bannerType);
+
+    List<EventBanner> findByIdIn(List<Long> bannerIds);
 }

--- a/src/main/java/com/example/skillup/domain/event/repository/EventBannerRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventBannerRepository.java
@@ -2,7 +2,7 @@ package com.example.skillup.domain.event.repository;
 
 import com.example.skillup.domain.event.entity.EventBanner;
 import com.example.skillup.domain.event.enums.BannerType;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -19,7 +19,32 @@ public interface EventBannerRepository extends JpaRepository<EventBanner, Long> 
             order by b.displayOrder asc
                 
 """)
-    List<EventBanner> findActiveEventBannersByType(@Param("bannerType") BannerType bannerType, @Param("now")LocalDateTime now, Pageable pageable);
+    List<EventBanner> findActiveEventBannersByType(@Param("bannerType") BannerType bannerType, @Param("now") LocalDate now);
+
+    @Query("""
+        select eb
+        from EventBanner eb
+        where eb.type = :bannerType
+          and eb.endAt < :now
+        order by eb.endAt desc
+    """)
+    List<EventBanner> findPastEventBannersByType(
+            @Param("bannerType") BannerType bannerType,
+            @Param("now") LocalDate now,
+            Pageable pageable
+    );
+
+    @Query("""
+        select eb
+        from EventBanner eb
+        where eb.type = :bannerType
+          and (eb.endAt is null or eb.endAt >= :now)
+        order by eb.displayOrder asc
+    """)
+    List<EventBanner> findCurrentAndWaitingEventBannersByType(
+            @Param("bannerType") BannerType bannerType,
+            @Param("now") LocalDate now
+    );
 
     Optional<EventBanner> findTopByTypeOrderByDisplayOrderDesc(BannerType bannerType);
 

--- a/src/main/java/com/example/skillup/domain/event/repository/EventBannerRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventBannerRepository.java
@@ -2,13 +2,13 @@ package com.example.skillup.domain.event.repository;
 
 import com.example.skillup.domain.event.entity.EventBanner;
 import com.example.skillup.domain.event.enums.BannerType;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 public interface EventBannerRepository extends JpaRepository<EventBanner, Long> {
     @Query("""
@@ -20,4 +20,6 @@ public interface EventBannerRepository extends JpaRepository<EventBanner, Long> 
                 
 """)
     List<EventBanner> findActiveEventBannersByType(@Param("bannerType") BannerType bannerType, @Param("now")LocalDateTime now, Pageable pageable);
+
+    Optional<EventBanner> findTopByTypeOrderByDisplayOrderDesc(BannerType bannerType);
 }

--- a/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
@@ -32,8 +32,8 @@ public class EventBannerService {
     public EventResponse.EventBannerResponse createBanner(MultipartFile Banner,
                                                           EventRequest.CreateEventBannerRequest request) {
 
-        String bannerSavePath = "banner/" + (request.getBannerType() == BannerType.MAIN_BANNER ? "main" : "sub");
-        int displayOrder = eventBannerRepository.findTopByTypeOrderByDisplayOrderDesc(request.getBannerType())
+        String bannerSavePath = "banner/main";
+        int displayOrder = eventBannerRepository.findTopByTypeOrderByDisplayOrderDesc(BannerType.MAIN_BANNER)
                 .map(EventBanner::getDisplayOrder).map(o -> o + 1).orElse(1);
         String bannerUrl = s3Service.uploadFile(Banner, bannerSavePath);
         EventBanner eventBanner = bannerMapper.toEventBanner(request, displayOrder, bannerUrl);
@@ -46,24 +46,21 @@ public class EventBannerService {
 
         List<EventBanner> mainBanners = eventBannerRepository.findActiveEventBannersByType(BannerType.MAIN_BANNER, now,
                 PageRequest.of(0, 5));
-        List<EventBanner> subBanner = eventBannerRepository.findActiveEventBannersByType(BannerType.SUB_BANNER, now,
-                PageRequest.of(0, 1));
 
         List<EventResponse.EventBannerResponse> mainEventBanners = bannerMapper.toEventBannerResponse(mainBanners);
-        List<EventResponse.EventBannerResponse> subEventBanners = bannerMapper.toEventBannerResponse(subBanner);
 
-        return bannerMapper.toEventBannersResponseList(mainEventBanners, subEventBanners);
+        return bannerMapper.toEventBannersResponseList(mainEventBanners);
 
     }
 
     @Transactional
-    public EventResponse.EventBannerResponse updateBanner(Long bannerId , EventRequest.UpdateEventBannerRequest request,
+    public EventResponse.EventBannerResponse updateBanner(Long bannerId, EventRequest.UpdateEventBannerRequest request,
                                                           MultipartFile bannerImage) {
         EventBanner banner = eventBannerRepository.findById(bannerId)
                 .orElseThrow(() -> new EventException(EventErrorCode.BANNER_ENTITY_NOT_FOUND));
 
         if (bannerImage != null && !bannerImage.isEmpty()) {
-            String bannerSavePath = "banner/" + (request.getBannerType() == BannerType.MAIN_BANNER ? "main" : "sub");
+            String bannerSavePath = "banner/main";
             String BannerUrl = s3Service.uploadFile(bannerImage, bannerSavePath);
             banner.updateBannerImage(BannerUrl);
         }

--- a/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
@@ -1,0 +1,86 @@
+package com.example.skillup.domain.event.service;
+
+
+import com.example.skillup.domain.event.dto.request.EventRequest;
+import com.example.skillup.domain.event.dto.response.EventResponse;
+import com.example.skillup.domain.event.entity.EventBanner;
+import com.example.skillup.domain.event.enums.BannerType;
+import com.example.skillup.domain.event.exception.EventErrorCode;
+import com.example.skillup.domain.event.exception.EventException;
+import com.example.skillup.domain.event.mapper.BannerMapper;
+import com.example.skillup.domain.event.repository.EventBannerRepository;
+import com.example.skillup.global.service.S3Service;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class EventBannerService {
+
+    private final EventBannerRepository eventBannerRepository;
+    private final BannerMapper bannerMapper;
+    private final S3Service s3Service;
+
+    LocalDateTime now = LocalDateTime.now();
+
+    @Transactional
+    public EventResponse.EventBannerResponse createBanner(MultipartFile Banner,
+                                                          EventRequest.CreateEventBannerRequest request) {
+
+        String bannerSavePath = "banner/" + (request.getBannerType() == BannerType.MAIN_BANNER ? "main" : "sub");
+        int displayOrder = eventBannerRepository.findTopByTypeOrderByDisplayOrderDesc(request.getBannerType())
+                .map(EventBanner::getDisplayOrder).map(o -> o + 1).orElse(1);
+        String bannerUrl = s3Service.uploadFile(Banner, bannerSavePath);
+        EventBanner eventBanner = bannerMapper.toEventBanner(request, displayOrder, bannerUrl);
+
+        return bannerMapper.toCreateBannerResponse(eventBannerRepository.save(eventBanner));
+    }
+
+    @Transactional(readOnly = true)
+    public EventResponse.EventBannersResponseList getEventBanners() {
+
+        List<EventBanner> mainBanners = eventBannerRepository.findActiveEventBannersByType(BannerType.MAIN_BANNER, now,
+                PageRequest.of(0, 5));
+        List<EventBanner> subBanner = eventBannerRepository.findActiveEventBannersByType(BannerType.SUB_BANNER, now,
+                PageRequest.of(0, 1));
+
+        List<EventResponse.EventBannerResponse> mainEventBanners = bannerMapper.toEventBannerResponse(mainBanners);
+        List<EventResponse.EventBannerResponse> subEventBanners = bannerMapper.toEventBannerResponse(subBanner);
+
+        return bannerMapper.toEventBannersResponseList(mainEventBanners, subEventBanners);
+
+    }
+
+    @Transactional
+    public EventResponse.EventBannerResponse updateBanner(Long bannerId , EventRequest.UpdateEventBannerRequest request,
+                                                          MultipartFile bannerImage) {
+        EventBanner banner = eventBannerRepository.findById(bannerId)
+                .orElseThrow(() -> new EventException(EventErrorCode.BANNER_ENTITY_NOT_FOUND));
+
+        if (bannerImage != null && !bannerImage.isEmpty()) {
+            String bannerSavePath = "banner/" + (request.getBannerType() == BannerType.MAIN_BANNER ? "main" : "sub");
+            String BannerUrl = s3Service.uploadFile(bannerImage, bannerSavePath);
+            banner.updateBannerImage(BannerUrl);
+        }
+
+        banner.updateInfo(request);
+
+        return bannerMapper.toCreateBannerResponse(banner);
+    }
+
+    @Transactional
+    public EventResponse.CommonBannerResponse deleteBanner(Long bannerId) {
+        EventBanner banner = eventBannerRepository.findById(bannerId)
+                .orElseThrow(() -> new EventException(EventErrorCode.BANNER_ENTITY_NOT_FOUND));
+
+        banner.delete();
+
+        return new EventResponse.CommonBannerResponse(banner.getId());
+    }
+
+}

--- a/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
@@ -10,8 +10,11 @@ import com.example.skillup.domain.event.exception.EventException;
 import com.example.skillup.domain.event.mapper.BannerMapper;
 import com.example.skillup.domain.event.repository.EventBannerRepository;
 import com.example.skillup.global.service.S3Service;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -26,7 +29,7 @@ public class EventBannerService {
     private final BannerMapper bannerMapper;
     private final S3Service s3Service;
 
-    LocalDateTime now = LocalDateTime.now();
+    LocalDate now = LocalDate.now();
 
     @Transactional
     public EventResponse.EventBannerResponse createBanner(MultipartFile Banner,
@@ -41,15 +44,34 @@ public class EventBannerService {
         return bannerMapper.toCreateBannerResponse(eventBannerRepository.save(eventBanner));
     }
 
-    @Transactional(readOnly = true)
-    public EventResponse.EventBannersResponseList getEventBanners() {
 
-        List<EventBanner> mainBanners = eventBannerRepository.findActiveEventBannersByType(BannerType.MAIN_BANNER, now,
-                PageRequest.of(0, 5));
+    //배너 관리자가 보는 배너들
+    //배너 종류 : 화면에 보이는 배너 + 시작 기간을 기다리고 있는 배너 / 이전 배너
+    @Transactional(readOnly = true)
+    public EventResponse.EventBannerAdminResponse getEventBanners(int page) {
+
+        int pageIndex = Math.max(0, page - 1);
+
+        List<EventBanner> mainBanners = eventBannerRepository.findCurrentAndWaitingEventBannersByType(
+                BannerType.MAIN_BANNER, now);
+        List<EventBanner> pastBanners = eventBannerRepository.findPastEventBannersByType(
+                BannerType.MAIN_BANNER, now, PageRequest.of(pageIndex, 5));
 
         List<EventResponse.EventBannerResponse> mainEventBanners = bannerMapper.toEventBannerResponse(mainBanners);
+        List<EventResponse.EventBannerResponse> pastEventBanners = bannerMapper.toEventBannerResponse(pastBanners);
 
-        return bannerMapper.toEventBannersResponseList(mainEventBanners);
+        return bannerMapper.toEventBannerAdminResponse(mainEventBanners, pastEventBanners);
+
+    }
+
+    //실제 화면에 띄울 배너들 모음
+    @Transactional(readOnly = true)
+    public EventResponse.EventBannersResponseList getActiveEventBanners() {
+        List<EventBanner> mainBanners = eventBannerRepository.findActiveEventBannersByType(BannerType.MAIN_BANNER, now);
+
+        List<EventResponse.EventBannerResponse> activeEventBanners = bannerMapper.toEventBannerResponse(mainBanners);
+
+        return bannerMapper.toEventBannersResponseList(activeEventBanners);
 
     }
 

--- a/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
@@ -80,4 +80,33 @@ public class EventBannerService {
         return new EventResponse.CommonBannerResponse(banner.getId());
     }
 
+    @Transactional
+    public void updateBannerOrder(List<Long> bannerIds) {
+        List<EventBanner> banners = eventBannerRepository.findByIdIn((bannerIds));
+
+        if (banners.size() != bannerIds.size()) {
+            throw new EventException(EventErrorCode.BANNER_ENTITY_NOT_FOUND, "존재하지 않는 배너 ID가 포함됐습니다.");
+        }
+
+        List<Long> invalidIds = banners.stream()
+                .filter(banner -> banner.getEndAt() == null || banner.getEndAt().isBefore(now))
+                .map(EventBanner::getId)
+                .toList();
+
+        if (!invalidIds.isEmpty()) {
+            throw new EventException(EventErrorCode.INVALID_BANNER_ID,
+                    "이미 기간이 지난 배너가 포함되어 있습니다. InvalidsIds= " + invalidIds);
+        }
+
+        Map<Long, EventBanner> bannerMap = banners.stream()
+                .collect(Collectors.toMap(EventBanner::getId, Function.identity()));
+
+        int order = 1;
+        for (Long id : bannerIds) {
+            EventBanner banner = bannerMap.get(id);
+            banner.updateBannerOrder(order++);
+        }
+
+    }
+
 }

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -5,13 +5,11 @@ import com.example.skillup.domain.event.dto.response.EventResponse;
 import com.example.skillup.domain.event.dto.response.EventResponse.EventApplyResponse;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventAction;
-import com.example.skillup.domain.event.entity.EventBanner;
 import com.example.skillup.domain.event.entity.EventLike;
 import com.example.skillup.domain.event.entity.HashTag;
 import com.example.skillup.domain.event.entity.TargetRole;
 import com.example.skillup.domain.event.enums.ActionType;
 import com.example.skillup.domain.event.enums.ActorType;
-import com.example.skillup.domain.event.enums.BannerType;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventStatus;
 import com.example.skillup.domain.event.exception.EventErrorCode;
@@ -116,15 +114,15 @@ public class EventService {
 
 
     @Transactional
-    public Event createEvent(EventRequest.CreateEvent request , MultipartFile thumbnailImage) {
+    public Event createEvent(EventRequest.CreateEvent request, MultipartFile thumbnailImage) {
 
         String thumbnailUrl = null;
 
-        if( thumbnailImage != null ) {
-            thumbnailUrl =  s3Service.uploadFile(thumbnailImage , "event/thumbnail");
+        if (thumbnailImage != null) {
+            thumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
         }
 
-        Event event = eventMapper.toEntity(request , thumbnailUrl);
+        Event event = eventMapper.toEntity(request, thumbnailUrl);
 
         request.getTargetRoles().stream()
                 .distinct()
@@ -167,21 +165,22 @@ public class EventService {
     }
 
     @Transactional
-    public EventResponse.CommonEventResponse updateEvent(Long eventId, EventRequest.UpdateEvent request , MultipartFile thumbnailImage) {
+    public EventResponse.CommonEventResponse updateEvent(Long eventId, EventRequest.UpdateEvent request,
+                                                         MultipartFile thumbnailImage) {
         Event event = eventRepository.getEvent(eventId);
 
         String imageUrl = event.getThumbnailUrl();
 
-        if(thumbnailImage != null && !thumbnailImage.isEmpty()) {
+        if (thumbnailImage != null && !thumbnailImage.isEmpty()) {
 
-            if(imageUrl != null && !imageUrl.isEmpty()) {
+            if (imageUrl != null && !imageUrl.isEmpty()) {
                 s3Service.deleteFileFromUrl(imageUrl);
             }
 
-            imageUrl = s3Service.uploadFile(thumbnailImage , "event/thumbnail");
+            imageUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
         }
 
-        event.update(request , imageUrl);
+        event.update(request, imageUrl);
 
         if (request.getTargetRoles() != null && !request.getTargetRoles().isEmpty()) {
             event.getTargetRoles().clear();
@@ -356,21 +355,6 @@ public class EventService {
         return eventMapper.toCategoryEventResponseList(items, category);
     }
 
-    @Transactional(readOnly = true)
-    public EventResponse.EventBannersResponseList getEventBanners() {
-
-        List<EventBanner> mainBanners = eventBannerRepository.findActiveEventBannersByType(BannerType.MAIN_BANNER, now,
-                PageRequest.of(0, 5));
-        List<EventBanner> subBanner = eventBannerRepository.findActiveEventBannersByType(BannerType.SUB_BANNER, now,
-                PageRequest.of(0, 1));
-
-        List<EventResponse.EventBannerResponse> mainEventBanners = eventMapper.toEventBannerResponse(mainBanners);
-        List<EventResponse.EventBannerResponse> subEventBanners = eventMapper.toEventBannerResponse(subBanner);
-
-        return eventMapper.toEventBannersResponseList(mainEventBanners, subEventBanners);
-
-    }
-
     private double calcPopularity(Event event) {
         //현재는 쿼리에서 직접 가져오는걸로 수정
         double views = event.getViewsCount();
@@ -412,9 +396,8 @@ public class EventService {
         List<EventRepositoryImpl.EventWithPopularity> events = eventRepository.findByCategoryWithSearch(condition,
                 pageable, since, now);
 
-        boolean targetRolesIsEmpty = condition.getTargetRoles() == null|| condition.getTargetRoles().isEmpty();
-        int targetRoleCount = targetRolesIsEmpty ? 0:condition.getTargetRoles().size() ;
-
+        boolean targetRolesIsEmpty = condition.getTargetRoles() == null || condition.getTargetRoles().isEmpty();
+        int targetRoleCount = targetRolesIsEmpty ? 0 : condition.getTargetRoles().size();
 
         int count = eventRepository.countByCategoryWithSearch(condition.getCategory().name(), condition.getIsOnline()
                 , condition.getIsFree(), condition.getStartDate(), condition.getEndDate(), condition.getTargetRoles(),
@@ -423,7 +406,7 @@ public class EventService {
                 targetRolesIsEmpty);
         CommonResponse.PageInfoResponse pageInfoResponse = CommonResponse.PageInfoResponse
                 .builder()
-                .currentPage(condition.getPage()+1)
+                .currentPage(condition.getPage() + 1)
                 .pageSize(pageable.getPageSize())
                 .totalPages((int) Math.ceil((double) count / (pageable.getPageSize())))
                 .build();
@@ -505,8 +488,9 @@ public class EventService {
 
         String actorId = (users != null) ? users.getUser().getId().toString() : guestId;
 
-        Optional<EventAction> eventAction = eventActionRepository.findByEventAndActorIdAndActionType(event, actorId, ActionType.APPLY);
-        if(eventAction.isPresent()) {
+        Optional<EventAction> eventAction = eventActionRepository.findByEventAndActorIdAndActionType(event, actorId,
+                ActionType.APPLY);
+        if (eventAction.isPresent()) {
             return EventResponse.EventApplyResponse.builder()
                     .eventId(eventId)
                     .comment("이미 신청한 이력이 있습니다. 정상적으로 처리 되었습니다.")
@@ -522,7 +506,7 @@ public class EventService {
                 .actionType(ActionType.APPLY)
                 .build();
 
-       eventRepository.incrementApplys(eventId);
+        eventRepository.incrementApplys(eventId);
 
         eventActionRepository.save(newEventAction);
 

--- a/src/main/java/com/example/skillup/global/config/SampleDataLoader.java
+++ b/src/main/java/com/example/skillup/global/config/SampleDataLoader.java
@@ -4,13 +4,16 @@ import com.example.skillup.domain.admin.entity.Admin;
 import com.example.skillup.domain.admin.enums.AdminRole;
 import com.example.skillup.domain.admin.repository.AdminRepository;
 import com.example.skillup.domain.event.entity.Event;
+import com.example.skillup.domain.event.entity.EventBanner;
 import com.example.skillup.domain.event.entity.EventLike;
 import com.example.skillup.domain.event.entity.EventViewDaily;
 import com.example.skillup.domain.event.entity.HashTag;
 import com.example.skillup.domain.event.entity.TargetRole;
+import com.example.skillup.domain.event.enums.BannerType;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventStatus;
 import com.example.skillup.domain.event.enums.HashTagCategory;
+import com.example.skillup.domain.event.repository.EventBannerRepository;
 import com.example.skillup.domain.event.repository.EventLikeRepository;
 import com.example.skillup.domain.event.repository.EventRepository;
 import com.example.skillup.domain.event.repository.EventViewDailyRepository;
@@ -48,6 +51,7 @@ public class SampleDataLoader implements CommandLineRunner {
     private final SynonymGroupRepository synonymGroupRepository;
     private final SynonymTermRepository synonymTermRepository;
     private final HashTagRepository hashTagRepository;
+    private final EventBannerRepository eventBannerRepository;
 
     @Override
     @Transactional
@@ -234,6 +238,92 @@ public class SampleDataLoader implements CommandLineRunner {
         makeSynonyms("ko", "카카오 관련 동의어", List.of("카카오", "kakao"));
         makeSynonyms("ko", "우테코 관련 동의어", List.of("우테코", "우아한테크코스", "woowacourse"));
         makeSynonyms("ko", "IT 기업 관련 동의어", List.of("네카라쿠배", "네이버", "카카오", "라인", "쿠팡"));
+
+
+        // === 5) 배너 더미 데이터 ===
+        LocalDate today = now.toLocalDate();
+
+// ① 현재 노출 중인 메인 배너 1 (부트캠프용)
+        EventBanner mainActiveBootcamp = EventBanner.builder()
+                .type(BannerType.MAIN_BANNER)
+                .bannerImageUrl("https://example.com/banner/backend-main.jpg")
+                .title("🔥 백엔드 부트캠프 지금 모집 중!")
+                .selected(true)
+                // 예: 상세 페이지로 이동하는 링크 (이벤트 id 활용)
+                .bannerLink("/events/" + bootcampOpen.getId())
+                .displayOrder(1)                     // 가장 위
+                .startAt(today.minusDays(5))         // 5일 전 시작
+                .endAt(today.plusDays(5))            // 5일 뒤까지 노출
+                .build();
+
+// ② 현재 노출 중인 메인 배너 2 (해커톤용)
+        EventBanner mainActiveHackathon = EventBanner.builder()
+                .type(BannerType.MAIN_BANNER)
+                .bannerImageUrl("https://example.com/banner/hackathon-main.jpg")
+                .title("🚀 AI 해커톤 2025 참가자 모집")
+                .selected(true)
+                .bannerLink("/events/" + hackathon.getId())
+                .displayOrder(2)                     // 두 번째
+                .startAt(today.minusDays(1))         // 어제 시작
+                .endAt(today.plusDays(10))           // 10일 뒤까지
+                .build();
+
+// ③ 시작 대기 중인 메인 배너 1
+        EventBanner mainWaitingSeminar = EventBanner.builder()
+                .type(BannerType.MAIN_BANNER)
+                .bannerImageUrl("https://example.com/banner/seminar-main.jpg")
+                .title("☁️ 클라우드 세미나 곧 시작 예정")
+                .selected(true)
+                .bannerLink("/events/" + seminarLate.getId())
+                .displayOrder(3)
+                .startAt(today.plusDays(3))          // 3일 뒤부터 노출
+                .endAt(today.plusDays(20))           // 20일 뒤까지
+                .build();
+
+// ④ 시작 대기 중인 메인 배너 2
+        EventBanner mainWaitingBootcampClosed = EventBanner.builder()
+                .type(BannerType.MAIN_BANNER)
+                .bannerImageUrl("https://example.com/banner/fe-waiting.jpg")
+                .title("프론트엔드 부트캠프 다음 기수 오픈 예정")
+                .selected(true)
+                .bannerLink("/events/" + bootcampClosed.getId())
+                .displayOrder(4)
+                .startAt(today.plusDays(7))          // 7일 뒤부터 노출
+                .endAt(today.plusDays(30))           // 30일 뒤까지
+                .build();
+
+// ⑤ 이미 종료된 과거 메인 배너 1
+        EventBanner mainPastOldBootcamp = EventBanner.builder()
+                .type(BannerType.MAIN_BANNER)
+                .bannerImageUrl("https://example.com/banner/backend-past.jpg")
+                .title("지난 기수 백엔드 부트캠프")
+                .selected(true)
+                .bannerLink("/events/" + bootcampOpen.getId())
+                .displayOrder(5)
+                .startAt(today.minusDays(30))        // 30일 전 시작
+                .endAt(today.minusDays(10))          // 10일 전에 종료 → 과거 배너
+                .build();
+
+// ⑥ 이미 종료된 과거 메인 배너 2
+        EventBanner mainPastOldHackathon = EventBanner.builder()
+                .type(BannerType.MAIN_BANNER)
+                .bannerImageUrl("https://example.com/banner/hackathon-past.jpg")
+                .title("지난 해커톤 다시보기")
+                .selected(true)
+                .bannerLink("/events/" + hackathon.getId())
+                .displayOrder(6)
+                .startAt(today.minusDays(60))
+                .endAt(today.minusDays(20))          // 역시 과거
+                .build();
+
+        eventBannerRepository.saveAll(List.of(
+                mainActiveBootcamp,
+                mainActiveHackathon,
+                mainWaitingSeminar,
+                mainWaitingBootcampClosed,
+                mainPastOldBootcamp,
+                mainPastOldHackathon
+        ));
 
     }
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

- 메인 배너 관리를 위한 **도메인·매퍼·서비스 구조**를 정리하고,
- **관리자용/사용자용 배너 조회 API**를 분리,
- **배너 노출 순서 정렬 API**를 추가했습니다.
- 추후 서브배너 확장까지 고려해 enum/필드 설계를 정리했습니다.

## 주요 변경 사항

### 1. 배너 도메인 및 매퍼 정리
- `EventBanner` 전용 `BannerMapper` 분리
  - `toCreateBannerResponse`, `toEventBanner` 등 엔티티 ↔ DTO 변환 책임 분리
- 필드/기본값 정리
  - `selected` 기본값 추가 (기본 노출 여부)
  - `startAt`, `endAt` 타입을 `LocalDate` 로 변경해 **일 단위 노출 기간 관리**가 명확해지도록 수정
- 컨트롤러/서비스/레포/enum 정리
  - 배너 생성/수정/삭제 API 컨트롤러 정리
  - `BannerType`, `BANNER_ENTITY_NOT_FOUND` 등 배너 전용 enum 추가

### 2. 배너 조회 API 세분화
- **관리자용 조회 API (`getEventBanners`)**
  - 아래 세 가지 그룹을 한 번에 조회하는 응답 구조 설계
    - 현재 화면에 노출 중인 배너
    - 노출 시작 전(대기) 배너
    - 이미 노출이 끝난 이전 배너
  - 이를 표현하기 위한 `EventBannerAdminResponse` 도입
  - 기간 기준 조회를 위해 레포에 메서드 추가  
    - `findPastEventBannersByType(...)`  
    - `findCurrentAndWaitingEventBannersByType(...)`
- **메인 화면용 조회 API (`getActiveEventBanners`)**
  - 현재 시점 기준, 노출 조건을 만족하는 배너만 반환
  - `displayOrder` 기준으로 정렬해 **UI에서 바로 사용 가능한 순서**로 전달
- 응답 포맷
  - `@JsonInclude(Include.NON_NULL)` 적용

### 3. 배너 순서 정렬 API 추가
- `BannerOrderUpdateRequest` 추가
  - 클라이언트에서 `배너 ID 리스트`를 넘기면, 해당 순서대로 `displayOrder` 재정렬
- 검증 로직
  - `EventBannerRepository.findByIdIn(...)` 으로 **전달된 ID 존재 여부 확인**
  - 노출 기간이 유효하지 않은 배너에 대해서는 정렬 대상에서 제외/에러 처리
  - 잘못된 ID에 대해서는 `EventErrorCode.INVALID_BANNER_ID` 응답
- 추후 서브배너가 추가될 것을 고려해, `bannerType` 은 유지한 채 로직만 보완

### 4. 기타 리팩토링 및 더미 데이터
- 서브배너 타입 제거로 인해 깨진 기존 로직 보완 
- 배너 관련 서비스/매퍼 코드 정리 및 불필요한 import 제거
- 로컬/테스트용으로 배너 더미 데이터 추가

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
