### PR TITLE
[FEAT] : 비회원 식별 쿠키 발급 및 행사 신청 프로세스 구현

### DIFF
--- a/src/main/java/com/example/skillup/SkillUpApplication.java
+++ b/src/main/java/com/example/skillup/SkillUpApplication.java
@@ -3,9 +3,11 @@ package com.example.skillup;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class SkillUpApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -12,11 +12,13 @@ import com.example.skillup.domain.event.service.EventBookmarkService;
 import com.example.skillup.domain.event.service.EventService;
 import com.example.skillup.domain.user.entity.UsersDetails;
 import com.example.skillup.global.common.BaseResponse;
+import com.example.skillup.global.interceptor.GuestIdInterceptor;
 import com.example.skillup.global.search.service.EventSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -112,9 +114,14 @@ public class EventController {
     public BaseResponse<EventResponse.EventSelectResponse> getEventDetail(
             @PathVariable Long eventId,
             @AuthenticationPrincipal(errorOnInvalidType = false) UsersDetails user,
-            @CookieValue(value = "guest_id", required = false) String guestId
+            @CookieValue(value = GuestIdInterceptor.GUEST_COOKIE_NAME, required = false) String guestId,
+            HttpServletRequest request
     ) {
-        EventResponse.EventSelectResponse response = eventService.getEventDetail(eventId, user, guestId);
+        String cookieGuestId = guestId;
+        if (cookieGuestId == null) {
+            cookieGuestId = request.getAttribute(GuestIdInterceptor.GUEST_ATTRIBUTE_NAME).toString();
+        }
+        EventResponse.EventSelectResponse response = eventService.getEventDetail(eventId, user, cookieGuestId);
         return BaseResponse.success("행사 상세 조회 성공", response);
     }
 
@@ -189,7 +196,7 @@ public class EventController {
             @RequestBody @Valid EventRequest.BannerOrderUpdateRequest request
     ) {
         eventBannerService.updateBannerOrder(request.getBannerIds());
-        return BaseResponse.success("배너 순서 수정 성공" ,null);
+        return BaseResponse.success("배너 순서 수정 성공", null);
     }
 
     @PutMapping(value = "/home/admin/banners/{bannerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -252,9 +259,15 @@ public class EventController {
             description = "로그인 유저는 userId 기반, 비로그인 유저는 guestId(쿠키) 기반으로 조회합니다.")
     public BaseResponse<List<EventResponse.HomeEventResponse>> getRecentEvents(
             @AuthenticationPrincipal UsersDetails user,
-            @CookieValue(value = "guest_id", required = false) String guestId) {
+            @CookieValue(value = GuestIdInterceptor.GUEST_COOKIE_NAME, required = false) String guestId,
+            HttpServletRequest request
+    ) {
+        String cookieGuestId = guestId;
+        if (cookieGuestId == null) {
+            cookieGuestId = request.getAttribute(GuestIdInterceptor.GUEST_ATTRIBUTE_NAME).toString();
+        }
         List<EventResponse.HomeEventResponse> events =
-                eventService.getRecentEvents(user != null ? String.valueOf(user.getUser().getId()) : guestId);
+                eventService.getRecentEvents(user != null ? String.valueOf(user.getUser().getId()) : cookieGuestId);
         return BaseResponse.success("홈 화면에서 최근 본 이벤트 조회 성공", events);
     }
 
@@ -272,9 +285,14 @@ public class EventController {
     public BaseResponse<EventApplyResponse> applyEvent(
             @PathVariable Long eventId,
             @AuthenticationPrincipal UsersDetails user,
-            @CookieValue(required = false) String guestId
+            @CookieValue(value = GuestIdInterceptor.GUEST_COOKIE_NAME, required = false) String guestId,
+            HttpServletRequest request
     ) {
-        return BaseResponse.success("지원 성공", eventService.applyEvent(eventId, user, guestId));
+        String cookieGuestId = guestId;
+        if (cookieGuestId == null) {
+            cookieGuestId = request.getAttribute(GuestIdInterceptor.GUEST_ATTRIBUTE_NAME).toString();
+        }
+        return BaseResponse.success("지원 성공", eventService.applyEvent(eventId, user, cookieGuestId));
     }
 
 }

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -25,8 +25,10 @@ import com.example.skillup.domain.event.repository.EventRepositoryImpl;
 import com.example.skillup.domain.event.repository.EventViewDailyRepository;
 import com.example.skillup.domain.event.repository.HashTagRepository;
 import com.example.skillup.domain.event.repository.TargetRoleRepository;
+import com.example.skillup.domain.user.entity.Guest;
 import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.domain.user.entity.UsersDetails;
+import com.example.skillup.domain.user.repository.GuestRepository;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.aop.ConvertNotFound;
 import com.example.skillup.global.aop.HandleDataAccessException;
@@ -55,6 +57,7 @@ public class EventService {
     private final TargetRoleRepository targetRoleRepository;
     private final EventLikeRepository eventLikeRepository;
     private final EventBookmarkService eventBookmarkService;
+    private final GuestRepository guestRepository;
     private final UserRepository userRepository;
     private final EventBannerRepository eventBannerRepository;
     private final EventActionRepository eventActionRepository;
@@ -66,6 +69,9 @@ public class EventService {
 
     LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
     LocalDateTime now = LocalDateTime.now();
+
+    private record ActorInfo(String actorId, ActorType actorType) {
+    }
 
     private static final Map<EventCategory, List<EventCategory>> CATEGORY_PRIORITY = Map.of(
             EventCategory.CONFERENCE_SEMINAR, List.of(
@@ -229,34 +235,36 @@ public class EventService {
                                                             String guestId) {
         Event event = eventRepository.getEvent(eventId);
 
-        //admin 아이디의 경우 변형 없음
+        ActorInfo actor = resolveAndSaveActor(user, guestId);
 
-        boolean isAdmin = false;
-        if (user != null) {
-            isAdmin = user.getAuthorities().stream()
-                    .anyMatch(a -> a.getAuthority().equals("ROLE_OWNER"));
-        }
+        boolean isAdmin = (user != null) && user.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_OWNER"));
 
-        // 일반 사용자는 공개된 게시글 아니면 볼 수 없음
         if (!isAdmin && event.getStatus() != EventStatus.PUBLISHED) {
             throw new EventException(CommonErrorCode.ACCESS_DENIED);
         }
 
-        //일반 사용자라면 북마크 여부 추가해주기
-        if (!isAdmin && user != null) {
-            boolean isBookmarked = eventBookmarkService.isBookmarked(user.getUser(), event);
+        boolean isBookmarked = false;
+        if (user != null && !isAdmin) {
+            isBookmarked = eventBookmarkService.isBookmarked(user.getUser(), event);
         }
 
-        String actorId = user != null ? user.getUser().getId().toString() : guestId;
-        ActorType actorType = user != null ? ActorType.USER : ActorType.GUEST;
-        ReadEvent(actorId, event, actorType);
+        readEvent(actor.actorId, event, actor.actorType);
 
         event = eventRepository.getEvent(eventId);
 
-        return eventMapper.toEventDetailInfo(event, false);
+        return eventMapper.toEventDetailInfo(event, isBookmarked);
     }
 
-    private void ReadEvent(String actorId, Event event, ActorType actorType) {
+    private void saveOrUpdateGuest(String guestId) {
+        Guest guest = guestRepository.findById(guestId)
+                .orElseGet(() -> Guest.builder().guestId(guestId).expiredAt(LocalDateTime.now().plusDays(30)).build());
+
+        guest.extendExpiration(30);
+        guestRepository.save(guest);
+    }
+
+    private void readEvent(String actorId, Event event, ActorType actorType) {
 
         //전체 조회수 및 event_view_daily 업데이트
         eventViewService.recordView(event.getId());
@@ -486,23 +494,22 @@ public class EventService {
     public EventResponse.EventApplyResponse applyEvent(Long eventId, UsersDetails users, String guestId) {
         Event event = eventRepository.getEvent(eventId);
 
-        String actorId = (users != null) ? users.getUser().getId().toString() : guestId;
+        ActorInfo actor = resolveAndSaveActor(users, guestId);
 
-        Optional<EventAction> eventAction = eventActionRepository.findByEventAndActorIdAndActionType(event, actorId,
+        Optional<EventAction> eventAction = eventActionRepository.findByEventAndActorIdAndActionType(event,
+                actor.actorId,
                 ActionType.APPLY);
+
         if (eventAction.isPresent()) {
             return EventResponse.EventApplyResponse.builder()
                     .eventId(eventId)
                     .comment("이미 신청한 이력이 있습니다. 정상적으로 처리 되었습니다.")
                     .build();
         }
-
-        ActorType actorType = users != null ? ActorType.USER : ActorType.GUEST;
-
         EventAction newEventAction = EventAction.builder()
                 .event(event)
-                .actorId(actorId)
-                .actorType(actorType)
+                .actorId(actor.actorId)
+                .actorType(actor.actorType)
                 .actionType(ActionType.APPLY)
                 .build();
 
@@ -514,5 +521,13 @@ public class EventService {
                 .eventId(eventId)
                 .comment("성공적으로 신청되었습니다.")
                 .build();
+    }
+
+    private ActorInfo resolveAndSaveActor(UsersDetails user, String guestId) {
+        if (user != null) {
+            return new ActorInfo(user.getUser().getId().toString(), ActorType.USER);
+        }
+        saveOrUpdateGuest(guestId);
+        return new ActorInfo(guestId, ActorType.GUEST);
     }
 }

--- a/src/main/java/com/example/skillup/domain/user/entity/Guest.java
+++ b/src/main/java/com/example/skillup/domain/user/entity/Guest.java
@@ -1,15 +1,16 @@
 package com.example.skillup.domain.user.entity;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import com.example.skillup.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
@@ -22,5 +23,10 @@ public class Guest  extends BaseEntity
     @Column(length = 100)
     private String guestId; // 쿠키로 발급한 UUID 값 (예: guest_83a2f1d0...)
 
-    //Guest 쿠키 값 유효 시간을 정해야 할 거 같음
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    public void extendExpiration(long days) {
+        this.expiredAt = LocalDateTime.now().plusDays(days);
+    }
 }

--- a/src/main/java/com/example/skillup/domain/user/repository/GuestRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/GuestRepository.java
@@ -1,0 +1,15 @@
+package com.example.skillup.domain.user.repository;
+
+import com.example.skillup.domain.user.entity.Guest;
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GuestRepository extends JpaRepository<Guest, String> {
+
+    @Modifying
+    @Query("DELETE FROM Guest g WHERE g.expiredAt < :now")
+    void deleteExpiredGuests(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/example/skillup/global/config/WebMvcConfig.java
+++ b/src/main/java/com/example/skillup/global/config/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package com.example.skillup.global.config;
+
+import com.example.skillup.global.interceptor.GuestIdInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final GuestIdInterceptor guestIdInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(guestIdInterceptor)
+                .addPathPatterns(
+                        "/events/home/recent",
+                        "/events/*/apply",
+                        "/events/*"
+                );
+    }
+}

--- a/src/main/java/com/example/skillup/global/interceptor/GuestIdInterceptor.java
+++ b/src/main/java/com/example/skillup/global/interceptor/GuestIdInterceptor.java
@@ -1,0 +1,56 @@
+package com.example.skillup.global.interceptor;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.UUID;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class GuestIdInterceptor implements HandlerInterceptor {
+
+    public static final String GUEST_COOKIE_NAME = "guest_id";
+    public static final String GUEST_ATTRIBUTE_NAME = "guest_id_attr";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+
+        String method = request.getMethod();
+        if (!HttpMethod.GET.matches(method) && !HttpMethod.PATCH.matches(method)) {
+            return true;
+        }
+        
+        String guestId = null;
+        if (request.getCookies() != null) {
+            guestId = Arrays.stream(request.getCookies())
+                    .filter(c -> c.getName().equals(GUEST_COOKIE_NAME))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        if (guestId == null) {
+            guestId = UUID.randomUUID().toString();
+        }
+
+        ResponseCookie cookie = ResponseCookie.from(GUEST_COOKIE_NAME, guestId)
+                .path("/")
+                .httpOnly(true)
+                .maxAge(60 * 60 * 24 * 30)
+                .sameSite("None")
+                .secure("https".equalsIgnoreCase(request.getScheme()) || request.isSecure())
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        request.setAttribute(GUEST_ATTRIBUTE_NAME, guestId);
+
+        return true;
+    }
+}

--- a/src/main/java/com/example/skillup/global/scheduler/GuestCleanupScheduler.java
+++ b/src/main/java/com/example/skillup/global/scheduler/GuestCleanupScheduler.java
@@ -1,0 +1,26 @@
+package com.example.skillup.global.scheduler;
+
+import com.example.skillup.domain.user.repository.GuestRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GuestCleanupScheduler {
+
+    private final GuestRepository guestRepository;
+
+    @Scheduled(cron = "0 0 4 * * *")//새벽 4시로 설정했습니다!
+    @Transactional
+    public void cleanupExpiredGuests() {
+        log.info("만료된 Guest 데이터 삭제 시작");
+        guestRepository.deleteExpiredGuests(LocalDateTime.now());
+        log.info("만료된 Guest 데이터 삭제 완료");
+    }
+
+}


### PR DESCRIPTION
## 개요
로그인하지 않은 사용자(Guest)도 '최근 본 행사'를 조회하고 행사를 신청할 수 있도록, **쿠키 기반의 비회원 식별 기능**을 구현했습니다.
불필요한 데이터 적재를 방지하기 위해 선택적으로 저장합니다., 만료된 비회원 데이터를 정리하는 스케줄러를 포함합니다.

전체적인 간단한 테스는 swagger 를 통해서 했습니다! 

자세한 성공 / 실패 / 예외 케이스 테스트는 다시 작성해서 아티클 테스트 시나리오와 함께 같이 올릴게요!

## 주요 변경 사항

### 1. 비회원 식별 시스템 구축 (Infrastructure)
* **GuestIdInterceptor 추가:**
    * 요청 시 `guest_id` 쿠키를 확인하고, 없을 경우 UUID를 생성하여 발급합니다.
    * 보안을 위해 `HttpOnly`, `Secure` 설정을 적용했습니다.
    * `GET`(조회), `PATCH`(신청) 메서드에만 동작하도록 최적화하여 불필요한 쿠키 발급을 방지했습니다.
* **WebMvcConfig:** `/api/events/*` 등 관련 경로에 인터셉터를 등록했습니다.

### 2. 서비스 로직 리팩토링 (EventService)
* **ActorInfo (Record) 도입:** 회원(User)과 비회원(Guest)의 식별 정보를 통합 관리하도록 구조를 개선했습니다.
* **Lazy Save 전략 적용:**
    * 단순 목록 조회 시에는 DB에 저장하지 않고 쿠키만 유지합니다.
    * **행사 신청(`applyEvent`)**이나 **상세 조회(`getEventDetail`)**와 같이 유의미한 액션이 발생할 때만 `Guest` 정보를 DB에 저장/갱신합니다.
* **resolveAndSaveActor 메서드 추출:** 중복되는 사용자 식별 및 저장 로직을 공통 메서드로 분리했습니다.

### 3. 데이터 생명주기 관리 (Domain & Scheduler)
* **Guest 엔티티 및 Repository:** 만료일 컬럼 추가 및 만료일 지난 행 삭제 메소드 추가했습니다.
* **GuestCleanupScheduler:** 매일 자정에 만료된(30일 경과) 비회원 데이터를 DB에서 삭제하는 스케줄러를 구현했습니다.
* **SkillUpApplication:** 스케줄링 기능 활성화를 위해 `@EnableScheduling`을 추가했습니다.

### 4. 컨트롤러 (EventController)
* 비회원 요청 시 `HttpServletRequest`의 Attribute에서 `guestId`를 안전하게 조회하도록 수정했습니다.

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
