### PR TITLE
[FEAT] 관리자 유저 조회 및 이벤트 활동 분석 API 추가

### DIFF
--- a/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
@@ -5,6 +5,7 @@ import com.example.skillup.domain.admin.dto.AdminResponse;
 import com.example.skillup.domain.admin.dto.SynonymRequest;
 import com.example.skillup.domain.admin.entity.Admin;
 import com.example.skillup.domain.admin.service.AdminService;
+import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.global.auth.dto.response.TokenResponse;
 import com.example.skillup.global.auth.service.AuthService;
 import com.example.skillup.global.common.BaseResponse;
@@ -81,7 +82,10 @@ public class AdminController {
         return BaseResponse.success("성공적으로 유저가 조회 되었습니다.", adminService.getUsersBySearch(keyWard,deleted));
     }
 
-    @GetMapping("/users/")
-
+    @GetMapping("/users/{userId}")
+    @Operation(summary = "유저 아이디로 유저를 상세 조회합니다.")
+    public BaseResponse<UserResponse.AdminUserDetailPageResponse> getUsersDetail(@PathVariable Long userId) {
+        return BaseResponse.success("유저 상세조회가 성공하였습니다.", adminService.getUsersDetail(userId));
+    }
 
 }

--- a/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.example.skillup.domain.admin.controller;
 
+import co.elastic.clients.elasticsearch.xpack.usage.Base;
 import com.example.skillup.domain.admin.dto.AdminLoginRequest;
 import com.example.skillup.domain.admin.dto.AdminResponse;
 import com.example.skillup.domain.admin.dto.SynonymRequest;
@@ -86,6 +87,12 @@ public class AdminController {
     @Operation(summary = "유저 아이디로 유저를 상세 조회합니다.")
     public BaseResponse<UserResponse.AdminUserDetailPageResponse> getUsersDetail(@PathVariable Long userId) {
         return BaseResponse.success("유저 상세조회가 성공하였습니다.", adminService.getUsersDetail(userId));
+    }
+
+    @GetMapping("/users/eventAction/counts/{userId}")
+    @Operation(summary = "유저 아이디로 유저의 활동 내역 횟수를 조회합니다.")
+    public BaseResponse<UserResponse.AdminUserEventActionResponse> getUserActionCounts(@PathVariable Long userId) {
+        return BaseResponse.success("유저 아이디로 유저의 활동 내역 조회 성공", adminService.getUserActionCounts(userId));
     }
 
 }

--- a/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
@@ -81,5 +81,7 @@ public class AdminController {
         return BaseResponse.success("성공적으로 유저가 조회 되었습니다.", adminService.getUsersBySearch(keyWard,deleted));
     }
 
+    @GetMapping("/users/")
+
 
 }

--- a/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.example.skillup.domain.admin.controller;
 
 import com.example.skillup.domain.admin.dto.AdminLoginRequest;
+import com.example.skillup.domain.admin.dto.AdminResponse;
 import com.example.skillup.domain.admin.dto.SynonymRequest;
 import com.example.skillup.domain.admin.entity.Admin;
 import com.example.skillup.domain.admin.service.AdminService;
@@ -11,13 +12,9 @@ import com.example.skillup.global.search.service.EventIndexerService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/admin")
@@ -76,4 +73,13 @@ public class AdminController {
     public BaseResponse<String> deleteGroup(@PathVariable Long groupId) {
         return BaseResponse.success("성공적으로 해당 그룹이 삭제되었습니다.", "지워진 동의어들 : " + adminService.deleteGroup(groupId));
     }
+
+
+    @GetMapping("/users")
+    @Operation(summary = "검색 조건으로 유저를 조회합니다.")
+    public BaseResponse<AdminResponse.AdminUserPageResponse> getUsersBySearch(@RequestParam(required = false) String keyWard , @RequestParam boolean deleted) {
+        return BaseResponse.success("성공적으로 유저가 조회 되었습니다.", adminService.getUsersBySearch(keyWard,deleted));
+    }
+
+
 }

--- a/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
@@ -92,7 +92,7 @@ public class AdminController {
 
     @GetMapping("/users/{userId}/eventAction/counts")
     @Operation(summary = "유저 아이디로 유저의 활동 내역 횟수를 조회합니다.")
-    public BaseResponse<UserResponse.AdminUserEventActionCountsResponse> getUserActionCounts(@PathVariable Long userId) {
+    public BaseResponse<UserResponse.AdminUserEventActionCountsResponse> getUserActionCounts(@PathVariable String userId) {
         return BaseResponse.success("유저 아이디로 유저의 활동 내역 횟수 조회 성공", adminService.getUserActionCounts(userId));
     }
 

--- a/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
@@ -79,8 +79,9 @@ public class AdminController {
 
     @GetMapping("/users")
     @Operation(summary = "검색 조건으로 유저를 조회합니다.")
-    public BaseResponse<AdminResponse.AdminUserPageResponse> getUsersBySearch(@RequestParam(required = false) String keyWard , @RequestParam boolean deleted) {
-        return BaseResponse.success("성공적으로 유저가 조회 되었습니다.", adminService.getUsersBySearch(keyWard,deleted));
+    public BaseResponse<AdminResponse.AdminUserPageResponse> getUsersBySearch(@RequestParam(required = false) String keyWard
+            , @RequestParam boolean deleted, @RequestParam int page) {
+        return BaseResponse.success("성공적으로 유저가 조회 되었습니다.", adminService.getUsersBySearch(keyWard,deleted,page));
     }
 
     @GetMapping("/users/{userId}")

--- a/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
@@ -89,10 +89,15 @@ public class AdminController {
         return BaseResponse.success("유저 상세조회가 성공하였습니다.", adminService.getUsersDetail(userId));
     }
 
-    @GetMapping("/users/eventAction/counts/{userId}")
+    @GetMapping("/users/{userId}/eventAction/counts")
     @Operation(summary = "유저 아이디로 유저의 활동 내역 횟수를 조회합니다.")
-    public BaseResponse<UserResponse.AdminUserEventActionResponse> getUserActionCounts(@PathVariable Long userId) {
-        return BaseResponse.success("유저 아이디로 유저의 활동 내역 조회 성공", adminService.getUserActionCounts(userId));
+    public BaseResponse<UserResponse.AdminUserEventActionCountsResponse> getUserActionCounts(@PathVariable Long userId) {
+        return BaseResponse.success("유저 아이디로 유저의 활동 내역 횟수 조회 성공", adminService.getUserActionCounts(userId));
     }
 
+    @GetMapping("/users/{userId}/eventAction/{actionType}/analytics")
+    @Operation(summary = "유저 아이디로 유저의 활동 내역 분석을 조회합니다.")
+    public BaseResponse<AdminResponse.eventActionAnalyticsResponse> getUserEventActionAnalytics(@PathVariable String userId, @PathVariable String actionType) {
+        return BaseResponse.success("유저 아이디로 유저의 활동 내역 분석 조회 성공", adminService.getUserEventActionAnalytics(userId,actionType));
+    }
 }

--- a/src/main/java/com/example/skillup/domain/admin/dto/AdminResponse.java
+++ b/src/main/java/com/example/skillup/domain/admin/dto/AdminResponse.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class AdminResponse {

--- a/src/main/java/com/example/skillup/domain/admin/dto/AdminResponse.java
+++ b/src/main/java/com/example/skillup/domain/admin/dto/AdminResponse.java
@@ -1,0 +1,28 @@
+package com.example.skillup.domain.admin.dto;
+
+import com.example.skillup.domain.user.dto.response.UserResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AdminResponse {
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class AdminUserPageResponse
+    {
+        List<UserResponse.AdminUserResponse> users;
+        List<UserResponse.AdminUserResponse> devUsers ;
+        List<UserResponse.AdminUserResponse> designerUsers;
+        List<UserResponse.AdminUserResponse> pmUsers;
+
+        int usersCount;
+        int devUsersCount;
+        int designerUsersCount;
+        int pmUsersCount;
+    }
+
+}

--- a/src/main/java/com/example/skillup/domain/admin/dto/AdminResponse.java
+++ b/src/main/java/com/example/skillup/domain/admin/dto/AdminResponse.java
@@ -1,6 +1,7 @@
 package com.example.skillup.domain.admin.dto;
 
 import com.example.skillup.domain.user.dto.response.UserResponse;
+import com.example.skillup.global.common.CommonResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,7 @@ public class AdminResponse {
         List<UserResponse.AdminUserResponse> designerUsers;
         List<UserResponse.AdminUserResponse> pmUsers;
 
+        CommonResponse.PageInfoResponse pageInfoResponse;
         int usersCount;
         int devUsersCount;
         int designerUsersCount;

--- a/src/main/java/com/example/skillup/domain/admin/dto/AdminResponse.java
+++ b/src/main/java/com/example/skillup/domain/admin/dto/AdminResponse.java
@@ -24,4 +24,35 @@ public class AdminResponse {
         int pmUsersCount;
     }
 
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class eventActionMonthlyCountResponse
+    {
+        int userMonthlyCount;
+        int othersMonthlyCount;
+        String monthLabels;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class  rolePercentageResponse
+    {
+        String role;
+        int percentage;
+    }
+
+
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class eventActionAnalyticsResponse
+    {
+        List<eventActionMonthlyCountResponse> eventActionMonthlyCountResponses;
+        List<rolePercentageResponse> rolePercentageResponses;
+    }
+
+
 }

--- a/src/main/java/com/example/skillup/domain/admin/mapper/AdminMapper.java
+++ b/src/main/java/com/example/skillup/domain/admin/mapper/AdminMapper.java
@@ -1,0 +1,31 @@
+package com.example.skillup.domain.admin.mapper;
+
+import com.example.skillup.domain.admin.dto.AdminResponse;
+import com.example.skillup.domain.admin.enums.AdminRole;
+import com.example.skillup.domain.user.dto.response.UserResponse;
+import com.example.skillup.domain.user.entity.Inquiry;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class AdminMapper {
+
+    public AdminResponse.AdminUserPageResponse toAdminUserPageResponse
+            (List<UserResponse.AdminUserResponse> users,
+             List<UserResponse.AdminUserResponse> devUsers,
+             List<UserResponse.AdminUserResponse> designerUsers,
+             List<UserResponse.AdminUserResponse> pmUsers
+             ) {
+        return AdminResponse.AdminUserPageResponse.builder()
+                .users(users)
+                .devUsers(devUsers)
+                .designerUsers(designerUsers)
+                .pmUsers(pmUsers)
+                .usersCount(users.size())
+                .devUsersCount(devUsers.size())
+                .designerUsersCount(designerUsers.size())
+                .pmUsersCount(pmUsers.size())
+                .build();
+    }
+}

--- a/src/main/java/com/example/skillup/domain/admin/mapper/AdminMapper.java
+++ b/src/main/java/com/example/skillup/domain/admin/mapper/AdminMapper.java
@@ -4,6 +4,7 @@ import com.example.skillup.domain.admin.dto.AdminResponse;
 import com.example.skillup.domain.admin.enums.AdminRole;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Inquiry;
+import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.global.common.CommonMapper;
 import org.springframework.stereotype.Component;
 
@@ -17,17 +18,27 @@ import java.util.Map;
 public class AdminMapper {
 
     public AdminResponse.AdminUserPageResponse toAdminUserPageResponse
-            (List<UserResponse.AdminUserResponse> users,
-             List<UserResponse.AdminUserResponse> devUsers,
-             List<UserResponse.AdminUserResponse> designerUsers,
-             List<UserResponse.AdminUserResponse> pmUsers
-             ) {
+            (List<UserResponse.AdminUserResponse> adminUserResponse)
+    {
+
+
+        List<UserResponse.AdminUserResponse> devUsers = new ArrayList<>();
+        List<UserResponse.AdminUserResponse> designerUsers = new ArrayList<>();
+        List<UserResponse.AdminUserResponse> pmUsers = new ArrayList<>();
+
+        for (UserResponse.AdminUserResponse u : adminUserResponse) {
+            switch (u.getRole()) {
+                case "개발" -> devUsers.add(u);
+                case "디자인" -> designerUsers.add(u);
+                default -> pmUsers.add(u);
+            }
+        }
         return AdminResponse.AdminUserPageResponse.builder()
-                .users(users)
+                .users(adminUserResponse)
                 .devUsers(devUsers)
                 .designerUsers(designerUsers)
                 .pmUsers(pmUsers)
-                .usersCount(users.size())
+                .usersCount(adminUserResponse.size())
                 .devUsersCount(devUsers.size())
                 .designerUsersCount(designerUsers.size())
                 .pmUsersCount(pmUsers.size())

--- a/src/main/java/com/example/skillup/domain/admin/mapper/AdminMapper.java
+++ b/src/main/java/com/example/skillup/domain/admin/mapper/AdminMapper.java
@@ -4,9 +4,14 @@ import com.example.skillup.domain.admin.dto.AdminResponse;
 import com.example.skillup.domain.admin.enums.AdminRole;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Inquiry;
+import com.example.skillup.global.common.CommonMapper;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Component
 public class AdminMapper {
@@ -26,6 +31,51 @@ public class AdminMapper {
                 .devUsersCount(devUsers.size())
                 .designerUsersCount(designerUsers.size())
                 .pmUsersCount(pmUsers.size())
+                .build();
+    }
+
+    public AdminResponse.eventActionAnalyticsResponse toEventActionAnalyticsResponse
+            (Map<String, Integer> rolePercentageMap,
+             Map<YearMonth, Integer> userMonthlyCountMap,
+             Map<YearMonth, Integer> othersMonthlyCountMap,
+             LocalDateTime since
+             )
+    {
+        List<AdminResponse.eventActionMonthlyCountResponse> eventActionMonthlyCountResponses
+                = new ArrayList<>();
+        YearMonth startMonth = YearMonth.from(since);
+
+        for (int i = 0; i < 6; i++) {
+            YearMonth month = startMonth.plusMonths(i);
+
+            eventActionMonthlyCountResponses.add(
+                    AdminResponse.eventActionMonthlyCountResponse.builder()
+                            .monthLabels(month.getMonthValue() + "월")
+                            .othersMonthlyCount(
+                                    othersMonthlyCountMap.getOrDefault(month, 0)
+                            )
+                            .userMonthlyCount(
+                                    userMonthlyCountMap.getOrDefault(month, 0)
+                            )
+                            .build()
+            );
+        }
+
+
+        List<AdminResponse.rolePercentageResponse> rolePercentageResponses
+                = new ArrayList<>();
+        for (Map.Entry<String, Integer> entry : rolePercentageMap.entrySet()) {
+            rolePercentageResponses.add(
+                    AdminResponse.rolePercentageResponse.builder()
+                            .role(CommonMapper.convertRole(entry.getKey()))
+                            .percentage(entry.getValue())
+                            .build());
+        }
+
+
+        return AdminResponse.eventActionAnalyticsResponse.builder()
+                .eventActionMonthlyCountResponses(eventActionMonthlyCountResponses)
+                .rolePercentageResponses(rolePercentageResponses)
                 .build();
     }
 }

--- a/src/main/java/com/example/skillup/domain/admin/mapper/AdminMapper.java
+++ b/src/main/java/com/example/skillup/domain/admin/mapper/AdminMapper.java
@@ -6,6 +6,8 @@ import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Inquiry;
 import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.global.common.CommonMapper;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.QPageRequest;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -18,7 +20,11 @@ import java.util.Map;
 public class AdminMapper {
 
     public AdminResponse.AdminUserPageResponse toAdminUserPageResponse
-            (List<UserResponse.AdminUserResponse> adminUserResponse)
+            (List<UserResponse.AdminUserResponse> adminUserResponse,
+             Pageable pageable,
+             int page,
+             int totalCount
+            )
     {
 
 
@@ -42,6 +48,9 @@ public class AdminMapper {
                 .devUsersCount(devUsers.size())
                 .designerUsersCount(designerUsers.size())
                 .pmUsersCount(pmUsers.size())
+                .pageInfoResponse(
+                        CommonMapper.toPageInfoResponse(pageable, page, totalCount)
+                )
                 .build();
     }
 

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -167,4 +167,11 @@ public class AdminService {
         Users user = userRepository.findById(userId).orElseThrow();
         return userMapper.toAdminUserDetailPageResponse(user);
     }
+
+    public UserResponse.AdminUserEventActionResponse getUserActionCounts(Long userId)
+    {
+        UserRepository.EventActionCountProjection usersActionCounts = userRepository.getUserActionCounts(userId);
+        return userMapper.toAdminUserEventActionResponse(usersActionCounts.getViewCnt()
+                ,usersActionCounts.getSaveCnt(),usersActionCounts.getApplyCnt());
+    }
 }

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -147,19 +147,7 @@ public class AdminService {
         for(Users user : users)
             adminUserResponse.add(userMapper.toAdminUserResponse(user));
 
-        List<UserResponse.AdminUserResponse> devUsers = new ArrayList<>();
-        List<UserResponse.AdminUserResponse> designerUsers = new ArrayList<>();
-        List<UserResponse.AdminUserResponse> pmUsers = new ArrayList<>();
-
-        for (UserResponse.AdminUserResponse u : adminUserResponse) {
-            switch (u.getRole()) {
-                case "개발" -> devUsers.add(u);
-                case "디자인" -> designerUsers.add(u);
-                default -> pmUsers.add(u);
-            }
-        }
-
-        return adminMapper.toAdminUserPageResponse(adminUserResponse, devUsers, designerUsers, pmUsers);
+        return adminMapper.toAdminUserPageResponse(adminUserResponse);
 
     }
 

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -180,7 +180,6 @@ public class AdminService {
         List<EventActionRepository.EventActionAnalyticsProjection> eventActionAnalytics
                 =  eventActionRepository.findEventActionsBySinceAndActionType(since, actionType);
 
-        System.out.println(eventActionAnalytics.size());
         List<EventActionRepository.EventActionAnalyticsProjection> usersEventActionAnalytics =
                 eventActionAnalytics.stream()
                         .filter(a -> Objects.equals(a.getActorId(), userId))
@@ -190,8 +189,7 @@ public class AdminService {
                 eventActionAnalytics.stream()
                         .filter(a -> !Objects.equals(a.getActorId(), userId))
                         .toList();
-        System.out.println(usersEventActionAnalytics.size());
-        System.out.println(othersEventActionAnalytics.size());
+
 
 
 

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -161,7 +161,7 @@ public class AdminService {
     )
     public UserResponse.AdminUserDetailPageResponse getUsersDetail(Long userId)
     {
-        Users user = userRepository.findById(userId).orElseThrow();
+        Users user = userRepository.findByIdNative(userId).orElseThrow();
         return userMapper.toAdminUserDetailPageResponse(user);
     }
 

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -9,8 +9,9 @@ import com.example.skillup.domain.admin.exception.AdminException;
 import com.example.skillup.domain.admin.mapper.AdminMapper;
 import com.example.skillup.domain.admin.mapper.SynonymMapper;
 import com.example.skillup.domain.admin.repository.AdminRepository;
-import com.example.skillup.domain.event.exception.EventException;
-import com.example.skillup.domain.event.exception.TargetRoleErrorCode;
+import com.example.skillup.domain.event.entity.TargetRole;
+import com.example.skillup.domain.event.enums.ActionType;
+import com.example.skillup.domain.event.repository.EventActionRepository;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.domain.user.exception.UserErrorCode;
@@ -19,6 +20,7 @@ import com.example.skillup.domain.user.mappers.UserMapper;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.aop.ConvertNotFound;
 import com.example.skillup.global.common.BaseEntity;
+import com.example.skillup.global.component.Calculator;
 import com.example.skillup.global.exception.CommonErrorCode;
 import com.example.skillup.global.exception.GlobalException;
 import com.example.skillup.global.search.component.ElasticsearchAdminClient;
@@ -29,8 +31,11 @@ import com.example.skillup.global.search.enums.SynonymStatus;
 import com.example.skillup.global.search.repository.SynonymGroupRepository;
 import com.example.skillup.global.search.repository.SynonymTermRepository;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.*;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -50,6 +55,7 @@ public class AdminService {
     private final UserRepository userRepository;
     private final AdminMapper adminMapper;
     private final UserMapper  userMapper;
+    private final EventActionRepository eventActionRepository;
 
 
     public Admin login(AdminLoginRequest request) {
@@ -168,10 +174,73 @@ public class AdminService {
         return userMapper.toAdminUserDetailPageResponse(user);
     }
 
-    public UserResponse.AdminUserEventActionResponse getUserActionCounts(Long userId)
+    public UserResponse.AdminUserEventActionCountsResponse getUserActionCounts(Long userId)
     {
         UserRepository.EventActionCountProjection usersActionCounts = userRepository.getUserActionCounts(userId);
         return userMapper.toAdminUserEventActionResponse(usersActionCounts.getViewCnt()
                 ,usersActionCounts.getSaveCnt(),usersActionCounts.getApplyCnt());
+    }
+
+    @Transactional(readOnly = true)
+    public AdminResponse.eventActionAnalyticsResponse getUserEventActionAnalytics(String userId,String actionType)
+    {
+        LocalDateTime since = LocalDate.now()
+                .withDayOfMonth(1)
+                .minusMonths(5)
+                .atStartOfDay();
+
+        List<EventActionRepository.EventActionAnalyticsProjection> eventActionAnalytics
+                =  eventActionRepository.findEventActionsBySinceAndActionType(since, actionType);
+
+        System.out.println(eventActionAnalytics.size());
+        List<EventActionRepository.EventActionAnalyticsProjection> usersEventActionAnalytics =
+                eventActionAnalytics.stream()
+                        .filter(a -> Objects.equals(a.getActorId(), userId))
+                        .toList();
+
+        List<EventActionRepository.EventActionAnalyticsProjection> othersEventActionAnalytics =
+                eventActionAnalytics.stream()
+                        .filter(a -> !Objects.equals(a.getActorId(), userId))
+                        .toList();
+        System.out.println(usersEventActionAnalytics.size());
+        System.out.println(othersEventActionAnalytics.size());
+
+
+
+        Map<String, Integer> roleCountMap = new HashMap<>();
+        int totalRoleCount = 0;
+
+        for (EventActionRepository.EventActionAnalyticsProjection action : usersEventActionAnalytics) {
+            String roles = action.getTargetRoles();
+            if (roles == null || roles.isBlank()) continue;
+
+            for (String roleName : roles.split(",")) {
+                roleCountMap.merge(roleName, 1, Integer::sum);
+                totalRoleCount++;
+            }
+        }
+
+        Map<String, Integer> rolePercentageMap =
+                Calculator.calculateWithHamilton(
+                        roleCountMap,
+                        totalRoleCount
+                );
+
+        Map<YearMonth, Integer> userMonthlyCountMap =
+                Calculator.countByMonth(usersEventActionAnalytics);
+
+        Map<YearMonth, Integer> othersMonthlyCountMap  =
+                Calculator.countByMonth(othersEventActionAnalytics);
+
+        int totalUserCount = userRepository.getTotalCount();
+
+        othersMonthlyCountMap.replaceAll((month, count) -> {
+            if (totalUserCount == 0) return 0;
+            return count / totalUserCount;
+        });
+
+
+        return adminMapper.toEventActionAnalyticsResponse(rolePercentageMap,userMonthlyCountMap,othersMonthlyCountMap,since);
+
     }
 }

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -9,10 +9,15 @@ import com.example.skillup.domain.admin.exception.AdminException;
 import com.example.skillup.domain.admin.mapper.AdminMapper;
 import com.example.skillup.domain.admin.mapper.SynonymMapper;
 import com.example.skillup.domain.admin.repository.AdminRepository;
+import com.example.skillup.domain.event.exception.EventException;
+import com.example.skillup.domain.event.exception.TargetRoleErrorCode;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Users;
+import com.example.skillup.domain.user.exception.UserErrorCode;
+import com.example.skillup.domain.user.exception.UserException;
 import com.example.skillup.domain.user.mappers.UserMapper;
 import com.example.skillup.domain.user.repository.UserRepository;
+import com.example.skillup.global.aop.ConvertNotFound;
 import com.example.skillup.global.common.BaseEntity;
 import com.example.skillup.global.exception.CommonErrorCode;
 import com.example.skillup.global.exception.GlobalException;
@@ -150,5 +155,16 @@ public class AdminService {
 
         return adminMapper.toAdminUserPageResponse(adminUserResponse, devUsers, designerUsers, pmUsers);
 
+    }
+
+    @ConvertNotFound(
+            exception = UserException.class,
+            errorCodeEnum = UserErrorCode.class,
+            errorCodeName = "USER_ENTITY_NOT_FOUND"
+    )
+    public UserResponse.AdminUserDetailPageResponse getUsersDetail(Long userId)
+    {
+        Users user = userRepository.findById(userId).orElseThrow();
+        return userMapper.toAdminUserDetailPageResponse(user);
     }
 }

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -38,6 +38,8 @@ import java.util.*;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -138,16 +140,17 @@ public class AdminService {
         return deletedTerms;
     }
 
-    public AdminResponse.AdminUserPageResponse getUsersBySearch(String keyWard, boolean deleted)
+    public AdminResponse.AdminUserPageResponse getUsersBySearch(String keyWard, boolean deleted,int page)
     {
-
-        List<Users> users= userRepository.findUsersByKeyWardAndDeleted(keyWard, deleted);
+        Pageable pageable = PageRequest.of(page, 20);
+        List<Users> users= userRepository.findUsersByKeyWardAndDeleted(keyWard, deleted, pageable);
         List<UserResponse.AdminUserResponse> adminUserResponse = new ArrayList<>();
 
         for(Users user : users)
             adminUserResponse.add(userMapper.toAdminUserResponse(user));
 
-        return adminMapper.toAdminUserPageResponse(adminUserResponse);
+        return adminMapper.toAdminUserPageResponse(adminUserResponse, pageable, page,
+        users.size());
 
     }
 

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -1,12 +1,18 @@
 package com.example.skillup.domain.admin.service;
 
 import com.example.skillup.domain.admin.dto.AdminLoginRequest;
+import com.example.skillup.domain.admin.dto.AdminResponse;
 import com.example.skillup.domain.admin.dto.SynonymRequest.AddTermsReq;
 import com.example.skillup.domain.admin.dto.SynonymRequest.CreateSynonymRequest;
 import com.example.skillup.domain.admin.entity.Admin;
 import com.example.skillup.domain.admin.exception.AdminException;
+import com.example.skillup.domain.admin.mapper.AdminMapper;
 import com.example.skillup.domain.admin.mapper.SynonymMapper;
 import com.example.skillup.domain.admin.repository.AdminRepository;
+import com.example.skillup.domain.user.dto.response.UserResponse;
+import com.example.skillup.domain.user.entity.Users;
+import com.example.skillup.domain.user.mappers.UserMapper;
+import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.common.BaseEntity;
 import com.example.skillup.global.exception.CommonErrorCode;
 import com.example.skillup.global.exception.GlobalException;
@@ -18,6 +24,7 @@ import com.example.skillup.global.search.enums.SynonymStatus;
 import com.example.skillup.global.search.repository.SynonymGroupRepository;
 import com.example.skillup.global.search.repository.SynonymTermRepository;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -35,6 +42,9 @@ public class AdminService {
     private final SynonymMapper synonymMapper;
     private final SynonymGroupRepository synonymGroupRepository;
     private final SynonymTermRepository synonymTermRepository;
+    private final UserRepository userRepository;
+    private final AdminMapper adminMapper;
+    private final UserMapper  userMapper;
 
 
     public Admin login(AdminLoginRequest request) {
@@ -115,5 +125,30 @@ public class AdminService {
         publish(locale);
 
         return deletedTerms;
+    }
+
+    public AdminResponse.AdminUserPageResponse getUsersBySearch(String keyWard, boolean deleted)
+    {
+
+        List<Users> users= userRepository.findUsersByKeyWardAndDeleted(keyWard, deleted);
+        List<UserResponse.AdminUserResponse> adminUserResponse = new ArrayList<>();
+
+        for(Users user : users)
+            adminUserResponse.add(userMapper.toAdminUserResponse(user));
+
+        List<UserResponse.AdminUserResponse> devUsers = new ArrayList<>();
+        List<UserResponse.AdminUserResponse> designerUsers = new ArrayList<>();
+        List<UserResponse.AdminUserResponse> pmUsers = new ArrayList<>();
+
+        for (UserResponse.AdminUserResponse u : adminUserResponse) {
+            switch (u.getRole()) {
+                case "개발" -> devUsers.add(u);
+                case "디자인" -> designerUsers.add(u);
+                default -> pmUsers.add(u);
+            }
+        }
+
+        return adminMapper.toAdminUserPageResponse(adminUserResponse, devUsers, designerUsers, pmUsers);
+
     }
 }

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -165,9 +165,9 @@ public class AdminService {
         return userMapper.toAdminUserDetailPageResponse(user);
     }
 
-    public UserResponse.AdminUserEventActionCountsResponse getUserActionCounts(Long userId)
+    public UserResponse.AdminUserEventActionCountsResponse getUserActionCounts(String actorId)
     {
-        UserRepository.EventActionCountProjection usersActionCounts = userRepository.getUserActionCounts(userId);
+        UserRepository.EventActionCountProjection usersActionCounts = userRepository.getUserActionCounts(actorId);
         return userMapper.toAdminUserEventActionResponse(usersActionCounts.getViewCnt()
                 ,usersActionCounts.getSaveCnt(),usersActionCounts.getApplyCnt());
     }

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -8,6 +8,8 @@ import com.example.skillup.domain.event.entity.HashTag;
 import com.example.skillup.domain.event.entity.TargetRole;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventStatus;
+import com.example.skillup.domain.event.repository.EventRepositoryImpl;
+import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.search.document.EventDocument;
 import java.text.NumberFormat;
 import java.time.LocalDateTime;
@@ -16,6 +18,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -197,6 +201,78 @@ public class EventMapper {
                 .homeEventResponseList(events)
                 .build();
     }
+
+    public EventResponse.SearchEventResponseList toCategoryPageEventResponseListWithPageable(
+            List<EventRepositoryImpl.EventWithPopularity> events,
+            Pageable pageable,
+            int page,
+            int totalCount
+    ) {
+        return EventResponse.SearchEventResponseList.builder()
+                .homeEventResponseList(
+                        events.stream()
+                                .map(r -> {
+                                    Event event = r.getEvent();
+                                    double score = r.getPopularity();
+                                    return toFeaturedEvent(
+                                            event,
+                                            false,
+                                            event.isRecommendedManual(),
+                                            event.isAd(),
+                                            score
+                                    );
+                                })
+                                .toList()
+                )
+                .total(totalCount)
+                .pageInfoResponse(
+                        CommonMapper.toPageInfoResponse(pageable, page, totalCount)
+                )
+                .build();
+    }
+
+    public List<EventResponse.HomeEventResponse> toHomeEventResponsList(List<Event> events) {
+        return events.stream()
+                .map(event ->
+                        toFeaturedEvent(
+                                event,
+                                false,
+                                event.isRecommendedManual(),
+                                event.isAd(),
+                                null
+                        )
+                )
+                .toList();
+    }
+
+    public List<EventResponse.HomeEventResponse> toCategoryPageEventResponseList(
+            List<EventRepositoryImpl.EventWithPopularity> events
+    ) {
+        return events.stream()
+                .map(r -> {
+                    Event event = r.getEvent();
+                    return toFeaturedEvent(
+                            event,
+                            false,
+                            event.isRecommendedManual(),
+                            event.isAd(),
+                            r.getPopularity()
+                    );
+                })
+                .toList();
+    }
+
+    public EventResponse.EventApplyResponse toEventApplyResponse(Long eventId)
+    {
+        return EventResponse.EventApplyResponse.builder()
+                .eventId(eventId)
+                .comment("성공적으로 신청되었습니다.")
+                .build();
+    }
+
+
+
+
 
     private String formatRange(LocalDateTime start, LocalDateTime end, DateTimeFormatter fmt) {
         if (start == null && end == null) {

--- a/src/main/java/com/example/skillup/domain/event/repository/EventActionRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventActionRepository.java
@@ -2,7 +2,10 @@ package com.example.skillup.domain.event.repository;
 
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventAction;
+import com.example.skillup.domain.event.entity.TargetRole;
 import com.example.skillup.domain.event.enums.ActionType;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -26,4 +29,35 @@ public interface EventActionRepository extends JpaRepository<EventAction, Long> 
     List<EventAction> findAllByEventAndActionType(Event event, ActionType actionType);
 
     Optional<EventAction> findByEventAndActorIdAndActionType(Event event, String actorId , ActionType actionType);
+
+
+    @Query(value = """
+    SELECT
+        ea.actor_id      AS actorId,
+        ea.created_at    AS createdAt,
+        GROUP_CONCAT(tr.name ORDER BY tr.name SEPARATOR ',') AS targetRoles
+    FROM event_action ea
+    JOIN event e
+        ON ea.event_id = e.id
+    JOIN event_target_role etr
+        ON e.id = etr.event_id
+    JOIN target_role tr
+        ON tr.id = etr.role_id
+    WHERE ea.created_at >= :since
+      AND ea.action_type = :actionType
+    GROUP BY ea.id, ea.actor_id, ea.created_at
+""", nativeQuery = true)
+    List<EventActionAnalyticsProjection> findEventActionsBySinceAndActionType(
+            @Param("since") LocalDateTime since,
+            @Param("actionType") String actionType
+    );
+
+
+    public interface  EventActionAnalyticsProjection
+    {
+        String getActorId();
+        LocalDateTime getCreatedAt();
+        String getTargetRoles();
+    }
+
 }

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -32,6 +32,7 @@ import com.example.skillup.domain.user.entity.UsersDetails;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.aop.ConvertNotFound;
 import com.example.skillup.global.aop.HandleDataAccessException;
+import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.common.CommonResponse;
 import com.example.skillup.global.exception.CommonErrorCode;
 import com.example.skillup.global.search.service.EventIndexerService;
@@ -421,20 +422,8 @@ public class EventService {
                 now,
                 targetRoleCount,
                 targetRolesIsEmpty);
-        CommonResponse.PageInfoResponse pageInfoResponse = CommonResponse.PageInfoResponse
-                .builder()
-                .currentPage(condition.getPage()+1)
-                .pageSize(pageable.getPageSize())
-                .totalPages((int) Math.ceil((double) count / (pageable.getPageSize())))
-                .build();
 
-        return EventResponse.SearchEventResponseList.builder().homeEventResponseList(events.stream()
-                .map(r -> {
-                    Event event = r.getEvent();
-                    double score = r.getPopularity();
-                    return eventMapper.toFeaturedEvent(event, false, event.isRecommendedManual(), event.isAd(), score);
-                })
-                .toList()).total(count).pageInfoResponse(pageInfoResponse).build();
+        return eventMapper.toCategoryPageEventResponseListWithPageable(events,pageable,condition.getPage(),count);
     }
 
     @Transactional(readOnly = true)
@@ -464,13 +453,7 @@ public class EventService {
             }
         }
 
-        return result.stream()
-                .map(r -> {
-                    Event event = r.getEvent();
-                    double score = r.getPopularity();
-                    return eventMapper.toFeaturedEvent(event, false, event.isRecommendedManual(), event.isAd(), score);
-                })
-                .toList();
+        return eventMapper.toCategoryPageEventResponseList(result);
     }
 
     @Transactional(readOnly = true)
@@ -478,11 +461,7 @@ public class EventService {
     public List<EventResponse.HomeEventResponse> getRecommendedEvents(Long actorId) {
         List<Event> events = eventRepository.findRecommendedEventForHome(actorId, since);
 
-        return events.stream()
-                .map(event -> {
-                    return eventMapper.toFeaturedEvent(event, false, event.isRecommendedManual(), event.isAd(), null);
-                })
-                .toList();
+        return eventMapper.toHomeEventResponsList(events);
     }
 
     @Transactional(readOnly = true)
@@ -491,11 +470,7 @@ public class EventService {
         Pageable pageable = PageRequest.of(0, 10);
         List<Event> events = eventActionRepository.findRecentEventsByActorId(actorId, pageable);
 
-        return events.stream()
-                .map(event -> {
-                    return eventMapper.toFeaturedEvent(event, false, event.isRecommendedManual(), event.isAd(), null);
-                })
-                .toList();
+        return eventMapper.toHomeEventResponsList(events);
 
     }
 
@@ -526,9 +501,6 @@ public class EventService {
 
         eventActionRepository.save(newEventAction);
 
-        return EventApplyResponse.builder()
-                .eventId(eventId)
-                .comment("성공적으로 신청되었습니다.")
-                .build();
+        return eventMapper.toEventApplyResponse(eventId);
     }
 }

--- a/src/main/java/com/example/skillup/domain/oauth/Entity/SocialLoginType.java
+++ b/src/main/java/com/example/skillup/domain/oauth/Entity/SocialLoginType.java
@@ -1,7 +1,15 @@
 package com.example.skillup.domain.oauth.Entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum SocialLoginType {
-    google,
-    kakao,
-    naver
-}
+    google("구글"),
+    kakao("카카오"),
+    naver("네이버");
+
+    private final String toKorean;
+
+    }

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -101,7 +101,7 @@ public class UserResponse {
     @Builder
     @Getter
     @AllArgsConstructor
-    public static class AdminUserEventActionResponse
+    public static class AdminUserEventActionCountsResponse
     {
         private int viewCount;
         private int saveCount;

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -69,6 +69,8 @@ public class UserResponse {
     }
 
     @Getter
+    @AllArgsConstructor
+    @Builder
     public static class AdminUserResponse
     {
         private Long userId;
@@ -79,23 +81,11 @@ public class UserResponse {
         private String role;
         private String status;
 
-        public AdminUserResponse(Long userId,String name,
-                                     String email,
-                                     LocalDateTime createdAt,
-                                     SocialLoginType socialLoginType,
-                                     TargetRole role,
-                                     boolean isDeleted) {
-            this.userId = userId;
-            this.name = name;
-            this.email = email;
-            this.createdAt = CommonMapper.toDatePattern(createdAt);
-            this.socialLoginType = socialLoginType.getToKorean();
-            this.role = CommonMapper.convertRole(role);
-            this.status = isDeleted ? "탈퇴" : "활성";
-        }
     }
 
     @Getter
+    @AllArgsConstructor
+    @Builder
     public static class AdminUserDetailPageResponse
     {
         private Long userId;
@@ -106,17 +96,15 @@ public class UserResponse {
         private String role;
         private String lastLoginAt;
 
-        public AdminUserDetailPageResponse(Long userId, String name, String email,
-                                           LocalDateTime createdAt, SocialLoginType socialLoginType,
-                                           TargetRole role, LocalDateTime lastLoginAt)
-        {
-            this.userId = userId;
-            this.name = name;
-            this.email = email;
-            this.createdAt = CommonMapper.toDatePattern(createdAt);
-            this.socialLoginType = socialLoginType.getToKorean()+" 로그인";
-            this.role = CommonMapper.convertRole(role);
-            this.lastLoginAt = CommonMapper.toDatePattern(lastLoginAt);
-        }
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class AdminUserEventActionResponse
+    {
+        private int viewCount;
+        private int saveCount;
+        private int applyCount;
     }
 }

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -70,6 +70,7 @@ public class UserResponse {
     @Getter
     public static class AdminUserResponse
     {
+        private Long userId;
         private String name;
         private String email;
         private String createdAt;
@@ -77,12 +78,13 @@ public class UserResponse {
         private String role;
         private String status;
 
-        public AdminUserResponse(String name,
+        public AdminUserResponse(Long userId,String name,
                                      String email,
                                      LocalDateTime createdAt,
                                      SocialLoginType socialLoginType,
                                      TargetRole role,
                                      boolean isDeleted) {
+            this.userId = userId;
             this.name = name;
             this.email = email;
             this.createdAt = CommonMapper.toDatePattern(createdAt);

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -95,6 +95,7 @@ public class UserResponse {
         private String socialLoginType;
         private String role;
         private String lastLoginAt;
+        private String status;
 
     }
 

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -1,15 +1,28 @@
 package com.example.skillup.domain.user.dto.response;
 
 import com.example.skillup.domain.event.dto.response.EventResponse;
+import com.example.skillup.domain.event.entity.TargetRole;
+import com.example.skillup.domain.oauth.Entity.SocialLoginType;
+import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.common.CommonResponse;
 import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class UserResponse {
+
+
+    public static String convertRole(TargetRole role) {
+        return switch (role.getName()) {
+            case "개발자" -> "개발";
+            case "디자이너" -> "디자인";
+            default ->  "기획";
+        };
+    }
     @Getter
     @AllArgsConstructor
     @Builder
@@ -59,5 +72,30 @@ public class UserResponse {
         private String question;
         private String answerTitle;
         private String answerContent;
+    }
+
+    @Getter
+    public static class AdminUserResponse
+    {
+        private String name;
+        private String email;
+        private String createdAt;
+        private String socialLoginType;
+        private String role;
+        private String status;
+
+        public AdminUserResponse(String name,
+                                     String email,
+                                     LocalDateTime createdAt,
+                                     SocialLoginType socialLoginType,
+                                     TargetRole role,
+                                     boolean isDeleted) {
+            this.name = name;
+            this.email = email;
+            this.createdAt = CommonMapper.toDatePattern(createdAt);
+            this.socialLoginType = socialLoginType.getToKorean();
+            this.role = convertRole(role);
+            this.status = isDeleted ? "탈퇴" : "활성";
+        }
     }
 }

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -16,13 +16,6 @@ import java.util.List;
 public class UserResponse {
 
 
-    public static String convertRole(TargetRole role) {
-        return switch (role.getName()) {
-            case "개발자" -> "개발";
-            case "디자이너" -> "디자인";
-            default ->  "기획";
-        };
-    }
     @Getter
     @AllArgsConstructor
     @Builder
@@ -94,7 +87,7 @@ public class UserResponse {
             this.email = email;
             this.createdAt = CommonMapper.toDatePattern(createdAt);
             this.socialLoginType = socialLoginType.getToKorean();
-            this.role = convertRole(role);
+            this.role = CommonMapper.convertRole(role);
             this.status = isDeleted ? "탈퇴" : "활성";
         }
     }

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -3,6 +3,7 @@ package com.example.skillup.domain.user.dto.response;
 import com.example.skillup.domain.event.dto.response.EventResponse;
 import com.example.skillup.domain.event.entity.TargetRole;
 import com.example.skillup.domain.oauth.Entity.SocialLoginType;
+import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.common.CommonResponse;
 import jakarta.persistence.Column;
@@ -91,6 +92,31 @@ public class UserResponse {
             this.socialLoginType = socialLoginType.getToKorean();
             this.role = CommonMapper.convertRole(role);
             this.status = isDeleted ? "탈퇴" : "활성";
+        }
+    }
+
+    @Getter
+    public static class AdminUserDetailPageResponse
+    {
+        private Long userId;
+        private String name;
+        private String email;
+        private String createdAt;
+        private String socialLoginType;
+        private String role;
+        private String lastLoginAt;
+
+        public AdminUserDetailPageResponse(Long userId, String name, String email,
+                                           LocalDateTime createdAt, SocialLoginType socialLoginType,
+                                           TargetRole role, LocalDateTime lastLoginAt)
+        {
+            this.userId = userId;
+            this.name = name;
+            this.email = email;
+            this.createdAt = CommonMapper.toDatePattern(createdAt);
+            this.socialLoginType = socialLoginType.getToKorean()+" 로그인";
+            this.role = CommonMapper.convertRole(role);
+            this.lastLoginAt = CommonMapper.toDatePattern(lastLoginAt);
         }
     }
 }

--- a/src/main/java/com/example/skillup/domain/user/entity/Users.java
+++ b/src/main/java/com/example/skillup/domain/user/entity/Users.java
@@ -45,7 +45,7 @@ public class Users extends BaseEntity
     private LocalDateTime regDatetime;
 
     @JoinColumn(nullable = false)
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private TargetRole role;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/skillup/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/skillup/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.skillup.domain.user.exception;
+
+import com.example.skillup.global.common.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ResultCode
+{
+    USER_ENTITY_NOT_FOUND("USER_ENTITY_NOT_FOUND","유저가 존재하지 않습니다", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -85,7 +85,7 @@ public class UserMapper {
 
     public UserResponse.AdminUserResponse toAdminUserResponse(Users user) {
         return new UserResponse.AdminUserResponse
-                (user.getName(), user.getEmail(), user.getCreatedAt(),
+                (user.getId(),user.getName(), user.getEmail(), user.getCreatedAt(),
                         user.getSocialLoginType(),user.getRole()
                         , user.getDeletedAt() != null);
     }

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -8,6 +8,7 @@ import com.example.skillup.domain.user.entity.Inquiry;
 import com.example.skillup.domain.user.entity.Interest;
 import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.domain.user.enums.UserStatus;
+import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.common.CommonResponse;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
@@ -84,16 +85,33 @@ public class UserMapper {
     }
 
     public UserResponse.AdminUserResponse toAdminUserResponse(Users user) {
-        return new UserResponse.AdminUserResponse
-                (user.getId(),user.getName(), user.getEmail(), user.getCreatedAt(),
-                        user.getSocialLoginType(),user.getRole()
-                        , user.getDeletedAt() != null);
+        return UserResponse.AdminUserResponse.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .createdAt(CommonMapper.toDatePattern(user.getCreatedAt()))
+                .email(user.getEmail())
+                .socialLoginType(user.getSocialLoginType().getToKorean())
+                .role(CommonMapper.convertRole(user.getRole()))
+                .status(user.getDeletedAt() != null? "탈퇴" : "활성").build();
     }
 
     public UserResponse.AdminUserDetailPageResponse toAdminUserDetailPageResponse(Users user) {
-        return new UserResponse.AdminUserDetailPageResponse(user.getId(),user.getName(), user.getEmail(), user.getCreatedAt(),
-                user.getSocialLoginType(),user.getRole()
-                , user.getLastLoginAt() );
+        return UserResponse.AdminUserDetailPageResponse.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .createdAt(CommonMapper.toDatePattern(user.getCreatedAt()))
+                .email(user.getEmail())
+                .socialLoginType(user.getSocialLoginType().getToKorean()+" 로그인")
+                .role(CommonMapper.convertRole(user.getRole()))
+                .lastLoginAt(CommonMapper.toDatePattern(user.getLastLoginAt())).build();
+    }
+
+    public UserResponse.AdminUserEventActionResponse toAdminUserEventActionResponse(int viewCount, int saveCount, int applyCount) {
+        return UserResponse.AdminUserEventActionResponse.builder()
+                .viewCount(viewCount)
+                .saveCount(saveCount)
+                .applyCount(applyCount)
+                .build();
     }
 
 }

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -83,4 +83,11 @@ public class UserMapper {
                 .build();
     }
 
+    public UserResponse.AdminUserResponse toAdminUserResponse(Users user) {
+        return new UserResponse.AdminUserResponse
+                (user.getName(), user.getEmail(), user.getCreatedAt(),
+                        user.getSocialLoginType(),user.getRole()
+                        , user.getDeletedAt() != null);
+    }
+
 }

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -91,7 +91,7 @@ public class UserMapper {
                 .createdAt(CommonMapper.toDatePattern(user.getCreatedAt()))
                 .email(user.getEmail())
                 .socialLoginType(user.getSocialLoginType().getToKorean())
-                .role(CommonMapper.convertRole(user.getRole()))
+                .role(CommonMapper.convertRole(user.getRole().getName()))
                 .status(user.getDeletedAt() != null? "탈퇴" : "활성").build();
     }
 
@@ -102,12 +102,12 @@ public class UserMapper {
                 .createdAt(CommonMapper.toDatePattern(user.getCreatedAt()))
                 .email(user.getEmail())
                 .socialLoginType(user.getSocialLoginType().getToKorean()+" 로그인")
-                .role(CommonMapper.convertRole(user.getRole()))
+                .role(CommonMapper.convertRole(user.getRole().getName()))
                 .lastLoginAt(CommonMapper.toDatePattern(user.getLastLoginAt())).build();
     }
 
-    public UserResponse.AdminUserEventActionResponse toAdminUserEventActionResponse(int viewCount, int saveCount, int applyCount) {
-        return UserResponse.AdminUserEventActionResponse.builder()
+    public UserResponse.AdminUserEventActionCountsResponse toAdminUserEventActionResponse(int viewCount, int saveCount, int applyCount) {
+        return UserResponse.AdminUserEventActionCountsResponse.builder()
                 .viewCount(viewCount)
                 .saveCount(saveCount)
                 .applyCount(applyCount)

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -103,7 +103,8 @@ public class UserMapper {
                 .email(user.getEmail())
                 .socialLoginType(user.getSocialLoginType().getToKorean()+" 로그인")
                 .role(CommonMapper.convertRole(user.getRole().getName()))
-                .lastLoginAt(CommonMapper.toDatePattern(user.getLastLoginAt())).build();
+                .lastLoginAt(CommonMapper.toDatePattern(user.getLastLoginAt()))
+                .status(user.getDeletedAt() != null? "탈퇴" : "활성").build();
     }
 
     public UserResponse.AdminUserEventActionCountsResponse toAdminUserEventActionResponse(int viewCount, int saveCount, int applyCount) {

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -90,4 +90,10 @@ public class UserMapper {
                         , user.getDeletedAt() != null);
     }
 
+    public UserResponse.AdminUserDetailPageResponse toAdminUserDetailPageResponse(Users user) {
+        return new UserResponse.AdminUserDetailPageResponse(user.getId(),user.getName(), user.getEmail(), user.getCreatedAt(),
+                user.getSocialLoginType(),user.getRole()
+                , user.getLastLoginAt() );
+    }
+
 }

--- a/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
@@ -54,4 +54,12 @@ WHERE ea.actorId = :actorId
     WHERE u.deletedAt IS NULL
     """)
     int getTotalCount();
+
+
+
+    @Query(
+            value = "SELECT * FROM users WHERE id = :userId",
+            nativeQuery = true
+    )
+    Optional<Users> findByIdNative(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<Users, Long>
 {
+
     Optional<Users> findByEmail(String email);
     Optional<Users> findBySocialId(String socialId);
 
@@ -25,4 +26,20 @@ public interface UserRepository extends JpaRepository<Users, Long>
                           
 """)
     List<Users> findUsersByKeyWardAndDeleted(@Param("keyWard") String keyWard, @Param("deleted") Boolean deleted);
+
+    @Query(value = """
+SELECT
+    SUM(ea.action_type = 'VIEW') AS viewCnt,
+    SUM(ea.action_type = 'APPLY') AS applyCnt,
+    SUM(ea.action_type = 'SAVE') AS saveCnt
+FROM event_action ea
+WHERE ea.user_id = :userId
+""", nativeQuery = true)
+    EventActionCountProjection getUserActionCounts(@Param("userId") Long userId);
+
+    public interface EventActionCountProjection {
+        int getViewCnt();
+        int getApplyCnt();
+        int getSaveCnt();
+    }
 }

--- a/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
@@ -17,26 +17,31 @@ public interface UserRepository extends JpaRepository<Users, Long>
     Optional<Users> findByEmail(String email);
     Optional<Users> findBySocialId(String socialId);
 
-    @Query("""
-    SELECT u
-    FROM Users u
+    @Query(
+            value = """
+    SELECT *
+    FROM users u
     WHERE
         (:deleted = true
-        OR :deleted = false AND u.deletedAt IS NULL)
-        AND (:keyWard IS NULL OR u.email LIKE %:keyWard% OR u.name LIKE %:keyWard%)
-                          
-""")
+         OR (:deleted = false AND u.deleted_at IS NULL))
+      AND (:keyword IS NULL
+           OR u.email LIKE CONCAT('%', :keyword, '%')
+           OR u.name  LIKE CONCAT('%', :keyword, '%'))
+    ORDER BY u.created_at DESC
+    """,
+            nativeQuery = true
+    )
     List<Users> findUsersByKeyWardAndDeleted(@Param("keyWard") String keyWard, @Param("deleted") Boolean deleted,Pageable pageable);
 
     @Query(value = """
 SELECT
-    SUM(ea.action_type = 'VIEW') AS viewCnt,
-    SUM(ea.action_type = 'APPLY') AS applyCnt,
-    SUM(ea.action_type = 'SAVE') AS saveCnt
+    COALESCE(SUM(ea.action_type = 'VIEW') AS viewCnt,0),
+    COALESCE(SUM(ea.action_type = 'APPLY') AS applyCnt,0),
+    COALESCE(SUM(ea.action_type = 'SAVE') AS saveCnt,0)
 FROM event_action ea
-WHERE ea.user_id = :userId
+WHERE ea.actorId = :actorId
 """, nativeQuery = true)
-    EventActionCountProjection getUserActionCounts(@Param("userId") Long userId);
+    EventActionCountProjection getUserActionCounts(@Param("actorId") String actorId);
 
     public interface EventActionCountProjection {
         int getViewCnt();

--- a/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
@@ -42,4 +42,10 @@ WHERE ea.user_id = :userId
         int getApplyCnt();
         int getSaveCnt();
     }
+    @Query(value = """
+    SELECT COUNT(*)
+    FROM Users u
+    WHERE u.deletedAt IS NULL
+    """)
+    int getTotalCount();
 }

--- a/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.example.skillup.domain.user.repository;
 
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Users;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,7 +26,7 @@ public interface UserRepository extends JpaRepository<Users, Long>
         AND (:keyWard IS NULL OR u.email LIKE %:keyWard% OR u.name LIKE %:keyWard%)
                           
 """)
-    List<Users> findUsersByKeyWardAndDeleted(@Param("keyWard") String keyWard, @Param("deleted") Boolean deleted);
+    List<Users> findUsersByKeyWardAndDeleted(@Param("keyWard") String keyWard, @Param("deleted") Boolean deleted,Pageable pageable);
 
     @Query(value = """
 SELECT

--- a/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
@@ -1,8 +1,13 @@
 package com.example.skillup.domain.user.repository;
 
+import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.userdetails.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<Users, Long>
@@ -10,4 +15,14 @@ public interface UserRepository extends JpaRepository<Users, Long>
     Optional<Users> findByEmail(String email);
     Optional<Users> findBySocialId(String socialId);
 
+    @Query("""
+    SELECT u
+    FROM Users u
+    WHERE
+        (:deleted = true
+        OR :deleted = false AND u.deletedAt IS NULL)
+        AND (:keyWard IS NULL OR u.email LIKE %:keyWard% OR u.name LIKE %:keyWard%)
+                          
+""")
+    List<Users> findUsersByKeyWardAndDeleted(@Param("keyWard") String keyWard, @Param("deleted") Boolean deleted);
 }

--- a/src/main/java/com/example/skillup/global/auth/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/example/skillup/global/auth/oauth/component/GoogleOauth.java
@@ -1,6 +1,6 @@
 package com.example.skillup.global.auth.oauth.component;
 
-import com.example.skillup.domain.oauth.component.HttpClientHelper;
+import com.example.skillup.global.component.HttpClientHelper;
 import com.example.skillup.domain.oauth.dto.OauthInfoRequest;
 import com.example.skillup.domain.oauth.exception.OauthErrorCode;
 import com.example.skillup.domain.oauth.exception.OauthException;

--- a/src/main/java/com/example/skillup/global/auth/oauth/component/KakaoOauth.java
+++ b/src/main/java/com/example/skillup/global/auth/oauth/component/KakaoOauth.java
@@ -1,6 +1,6 @@
 package com.example.skillup.global.auth.oauth.component;
 
-import com.example.skillup.domain.oauth.component.HttpClientHelper;
+import com.example.skillup.global.component.HttpClientHelper;
 import com.example.skillup.domain.oauth.dto.OauthInfoRequest;
 import com.example.skillup.domain.oauth.exception.OauthErrorCode;
 import com.example.skillup.domain.oauth.exception.OauthException;

--- a/src/main/java/com/example/skillup/global/auth/oauth/component/NaverOauth.java
+++ b/src/main/java/com/example/skillup/global/auth/oauth/component/NaverOauth.java
@@ -1,6 +1,6 @@
 package com.example.skillup.global.auth.oauth.component;
 
-import com.example.skillup.domain.oauth.component.HttpClientHelper;
+import com.example.skillup.global.component.HttpClientHelper;
 import com.example.skillup.domain.oauth.dto.OauthInfoRequest;
 import com.example.skillup.domain.oauth.exception.OauthErrorCode;
 import com.example.skillup.domain.oauth.exception.OauthException;

--- a/src/main/java/com/example/skillup/global/common/CommonMapper.java
+++ b/src/main/java/com/example/skillup/global/common/CommonMapper.java
@@ -1,0 +1,15 @@
+package com.example.skillup.global.common;
+
+import com.example.skillup.domain.user.dto.response.UserResponse;
+import com.example.skillup.domain.user.entity.Users;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class CommonMapper {
+    public static String toDatePattern(LocalDateTime dateTime)
+    {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
+        return dateTime.format(formatter);
+    }
+}

--- a/src/main/java/com/example/skillup/global/common/CommonMapper.java
+++ b/src/main/java/com/example/skillup/global/common/CommonMapper.java
@@ -14,8 +14,8 @@ public class CommonMapper {
         return dateTime.format(formatter);
     }
 
-    public static String convertRole(TargetRole role) {
-        return switch (role.getName()) {
+    public static String convertRole(String role) {
+        return switch (role) {
             case "개발자" -> "개발";
             case "디자이너" -> "디자인";
             default ->  "기획";

--- a/src/main/java/com/example/skillup/global/common/CommonMapper.java
+++ b/src/main/java/com/example/skillup/global/common/CommonMapper.java
@@ -3,6 +3,7 @@ package com.example.skillup.global.common;
 import com.example.skillup.domain.event.entity.TargetRole;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Users;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -20,5 +21,16 @@ public class CommonMapper {
             case "디자이너" -> "디자인";
             default ->  "기획";
         };
+    }
+
+    public static CommonResponse.PageInfoResponse toPageInfoResponse
+            (Pageable pageable, int page,int count)
+    {
+        return CommonResponse.PageInfoResponse
+                .builder()
+                .currentPage(page+1)
+                .pageSize(pageable.getPageSize())
+                .totalPages((int) Math.ceil((double) count / (pageable.getPageSize())))
+                .build();
     }
 }

--- a/src/main/java/com/example/skillup/global/common/CommonMapper.java
+++ b/src/main/java/com/example/skillup/global/common/CommonMapper.java
@@ -1,5 +1,6 @@
 package com.example.skillup.global.common;
 
+import com.example.skillup.domain.event.entity.TargetRole;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Users;
 
@@ -11,5 +12,13 @@ public class CommonMapper {
     {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
         return dateTime.format(formatter);
+    }
+
+    public static String convertRole(TargetRole role) {
+        return switch (role.getName()) {
+            case "개발자" -> "개발";
+            case "디자이너" -> "디자인";
+            default ->  "기획";
+        };
     }
 }

--- a/src/main/java/com/example/skillup/global/component/Calculator.java
+++ b/src/main/java/com/example/skillup/global/component/Calculator.java
@@ -1,0 +1,73 @@
+package com.example.skillup.global.component;
+
+import com.example.skillup.domain.event.repository.EventActionRepository;
+
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class Calculator {
+
+    private Calculator() {
+    }
+    public static Map<YearMonth, Integer> countByMonth(
+            List<EventActionRepository.EventActionAnalyticsProjection> actions
+    ) {
+        return actions.stream()
+                .collect(Collectors.groupingBy(
+                        a -> YearMonth.from(a.getCreatedAt()),
+                        Collectors.summingInt(e -> 1)
+                ));
+    }
+
+    public static Map<String, Integer> calculateWithHamilton(
+            Map<String, Integer> countMap,
+            int totalCount
+    ) {
+        if (totalCount == 0 || countMap.isEmpty()) {
+            return Map.of();
+        }
+
+        class Temp {
+            String key;
+            int floor;
+            double remainder;
+
+            Temp(String key, int floor, double remainder) {
+                this.key = key;
+                this.floor = floor;
+                this.remainder = remainder;
+            }
+        }
+
+        List<Temp> temps = new ArrayList<>();
+        int sum = 0;
+
+        for (Map.Entry<String, Integer> entry : countMap.entrySet()) {
+            double exact = entry.getValue() * 100.0 / totalCount;
+            int floor = (int) exact;
+            double remainder = exact - floor;
+
+            temps.add(new Temp(entry.getKey(), floor, remainder));
+            sum += floor;
+        }
+
+        int remain = 100 - sum;
+
+        temps.sort((a, b) -> Double.compare(b.remainder, a.remainder));
+
+        for (int i = 0; i < remain; i++) {
+            temps.get(i).floor++;
+        }
+
+        Map<String, Integer> result = new LinkedHashMap<>();
+        for (Temp temp : temps) {
+            result.put(temp.key, temp.floor);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/example/skillup/global/component/HttpClientHelper.java
+++ b/src/main/java/com/example/skillup/global/component/HttpClientHelper.java
@@ -1,4 +1,4 @@
-package com.example.skillup.domain.oauth.component;
+package com.example.skillup.global.component;
 
 import com.example.skillup.domain.oauth.exception.OauthErrorCode;
 import com.example.skillup.domain.oauth.exception.OauthException;

--- a/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
@@ -249,7 +249,6 @@ public class adminServiceTest
                 }
             }
         }
-
         AdminResponse.eventActionAnalyticsResponse response1=adminService.getUserEventActionAnalytics("1L","VIEW");
         for(AdminResponse.eventActionMonthlyCountResponse a :response1.getEventActionMonthlyCountResponses())
         {

--- a/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
@@ -149,7 +149,7 @@ public class adminServiceTest
     @Test
     public void getUserBySearch_Success()
     {
-        AdminResponse.AdminUserPageResponse response1 =adminService.getUsersBySearch(null,false);
+        AdminResponse.AdminUserPageResponse response1 =adminService.getUsersBySearch(null,false,0);
         for(UserResponse.AdminUserResponse u : response1.getUsers())
         {
             System.out.println(u.getRole());
@@ -166,7 +166,7 @@ public class adminServiceTest
 
 
 
-        AdminResponse.AdminUserPageResponse response2 = adminService.getUsersBySearch("철",false);
+        AdminResponse.AdminUserPageResponse response2 = adminService.getUsersBySearch("철",false,0);
 
         assertThat(1).isEqualTo(response2.getUsers().size());
         assertThat(1).isEqualTo(response2.getPmUsers().size());
@@ -174,7 +174,7 @@ public class adminServiceTest
         assertThat(0).isEqualTo(response2.getDesignerUsers().size());
 
 
-        AdminResponse.AdminUserPageResponse response3 = adminService.getUsersBySearch("철",true);
+        AdminResponse.AdminUserPageResponse response3 = adminService.getUsersBySearch("철",true,0);
         assertThat(1
         ).isEqualTo(response2.getUsers().size());
 

--- a/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
@@ -1,0 +1,165 @@
+package com.example.skillup.domain.admin.service;
+
+
+import com.example.skillup.domain.admin.dto.AdminResponse;
+import com.example.skillup.domain.event.entity.TargetRole;
+import com.example.skillup.domain.event.repository.TargetRoleRepository;
+import com.example.skillup.domain.oauth.Entity.SocialLoginType;
+import com.example.skillup.domain.user.dto.response.UserResponse;
+import com.example.skillup.domain.user.entity.Users;
+import com.example.skillup.domain.user.enums.UserStatus;
+import com.example.skillup.domain.user.repository.UserRepository;
+import com.example.skillup.global.common.BaseEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class adminServiceTest
+{
+    @Autowired
+    private AdminService adminService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private TargetRoleRepository targetRoleRepository;
+
+    @BeforeEach
+    void setup() throws NoSuchFieldException, IllegalAccessException {
+        userRepository.deleteAll();
+        TargetRole role =targetRoleRepository.save(TargetRole.builder().name("개발자").build());
+        TargetRole role1 =targetRoleRepository.save(TargetRole.builder().name("디자이너").build());
+        TargetRole role2 =targetRoleRepository.save(TargetRole.builder().name("기획자").build());
+        userRepository.save(
+                Users.builder()
+                        .email("seed1@ex.com")
+                        .name("Seed1")
+                        .gender("남")
+                        .age("15")
+                        .jobGroup("개발자")
+                        .notificationFlag("Y")
+                        .socialId("test12")
+                        .regDatetime(LocalDateTime.now())
+                        .socialLoginType(SocialLoginType.google)
+                        .lastLoginAt(LocalDateTime.now())
+                        .status(UserStatus.ACTIVE)
+                        .role(role)
+                        .build()
+        );
+        userRepository.save(
+                Users.builder()
+                        .email("seed2@ex.com")
+                        .name("Seed1")
+                        .gender("남")
+                        .age("15")
+                        .jobGroup("개발자")
+                        .notificationFlag("Y")
+                        .socialId("test3")
+                        .regDatetime(LocalDateTime.now())
+                        .socialLoginType(SocialLoginType.google)
+                        .lastLoginAt(LocalDateTime.now())
+                        .status(UserStatus.ACTIVE)
+                        .role(role1)
+                        .build()
+        );
+        userRepository.save(
+                Users.builder()
+                        .email("seed3@ex.com")
+                        .name("Seed1")
+                        .gender("남")
+                        .age("15")
+                        .jobGroup("개발자")
+                        .notificationFlag("Y")
+                        .socialId("test444")
+                        .regDatetime(LocalDateTime.now())
+                        .socialLoginType(SocialLoginType.google)
+                        .lastLoginAt(LocalDateTime.now())
+                        .status(UserStatus.ACTIVE)
+                        .role(role2)
+                        .build()
+        );
+        userRepository.save(
+                Users.builder()
+                        .email("seed4@ex.com")
+                        .name("김철수")
+                        .gender("남")
+                        .age("15")
+                        .jobGroup("개발자")
+                        .notificationFlag("Y")
+                        .socialId("test2")
+                        .regDatetime(LocalDateTime.now())
+                        .socialLoginType(SocialLoginType.google)
+                        .lastLoginAt(LocalDateTime.now())
+                        .status(UserStatus.ACTIVE)
+                        .role(role2)
+                        .build()
+        );
+
+        Users oldUsers=  Users.builder()
+                .email("seed5@ex.com")
+                .name("김철수")
+                .gender("남")
+                .age("15")
+                .jobGroup("개발자")
+                .notificationFlag("Y")
+                .socialId("test2")
+                .regDatetime(LocalDateTime.now())
+                .socialLoginType(SocialLoginType.google)
+                .lastLoginAt(LocalDateTime.now())
+                .status(UserStatus.ACTIVE)
+                .role(role2)
+                .build();
+        Field createdField = BaseEntity.class.getDeclaredField("deletedAt");
+        createdField.setAccessible(true);
+
+        createdField.set(oldUsers, LocalDate.now().minusMonths(5).atStartOfDay());
+        userRepository.save(oldUsers);
+    }
+
+
+    @Test
+    public void getUserBySearch_Success()
+    {
+        AdminResponse.AdminUserPageResponse response1 =adminService.getUsersBySearch(null,false);
+        for(UserResponse.AdminUserResponse u : response1.getUsers())
+        {
+            System.out.println(u.getRole());
+            System.out.println(u.getEmail());
+            System.out.println(u.getName());
+            System.out.println(u.getCreatedAt());
+            System.out.println(u.getStatus());
+            System.out.println(u.getSocialLoginType());
+        }
+        assertThat(4).isEqualTo(response1.getUsers().size());
+        assertThat(2).isEqualTo(response1.getPmUsers().size());
+        assertThat(1).isEqualTo(response1.getDevUsers().size());
+        assertThat(1).isEqualTo(response1.getDesignerUsers().size());
+
+
+
+        AdminResponse.AdminUserPageResponse response2 = adminService.getUsersBySearch("철",false);
+
+        assertThat(1).isEqualTo(response2.getUsers().size());
+        assertThat(1).isEqualTo(response2.getPmUsers().size());
+        assertThat(0).isEqualTo(response2.getDevUsers().size());
+        assertThat(0).isEqualTo(response2.getDesignerUsers().size());
+
+
+        AdminResponse.AdminUserPageResponse response3 = adminService.getUsersBySearch("철",true);
+        assertThat(1
+        ).isEqualTo(response2.getUsers().size());
+
+    }
+
+}

--- a/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
@@ -2,7 +2,16 @@ package com.example.skillup.domain.admin.service;
 
 
 import com.example.skillup.domain.admin.dto.AdminResponse;
+import com.example.skillup.domain.event.entity.Event;
+import com.example.skillup.domain.event.entity.EventAction;
+import com.example.skillup.domain.event.entity.HashTag;
 import com.example.skillup.domain.event.entity.TargetRole;
+import com.example.skillup.domain.event.enums.ActionType;
+import com.example.skillup.domain.event.enums.ActorType;
+import com.example.skillup.domain.event.enums.EventCategory;
+import com.example.skillup.domain.event.enums.EventStatus;
+import com.example.skillup.domain.event.repository.EventActionRepository;
+import com.example.skillup.domain.event.repository.EventRepository;
 import com.example.skillup.domain.event.repository.TargetRoleRepository;
 import com.example.skillup.domain.oauth.Entity.SocialLoginType;
 import com.example.skillup.domain.user.dto.response.UserResponse;
@@ -20,7 +29,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.*;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,13 +45,20 @@ public class adminServiceTest
     private UserRepository userRepository;
     @Autowired
     private TargetRoleRepository targetRoleRepository;
+    @Autowired
+    private EventRepository eventRepository;
+    @Autowired
+    private EventActionRepository eventActionRepository;
+    TargetRole role;
+    TargetRole role1;
+    TargetRole role2;
 
     @BeforeEach
     void setup() throws NoSuchFieldException, IllegalAccessException {
         userRepository.deleteAll();
-        TargetRole role =targetRoleRepository.save(TargetRole.builder().name("개발자").build());
-        TargetRole role1 =targetRoleRepository.save(TargetRole.builder().name("디자이너").build());
-        TargetRole role2 =targetRoleRepository.save(TargetRole.builder().name("기획자").build());
+        role =targetRoleRepository.save(TargetRole.builder().name("개발자").build());
+        role1 =targetRoleRepository.save(TargetRole.builder().name("디자이너").build());
+        role2 =targetRoleRepository.save(TargetRole.builder().name("기획자").build());
         userRepository.save(
                 Users.builder()
                         .email("seed1@ex.com")
@@ -163,6 +179,36 @@ public class adminServiceTest
         ).isEqualTo(response2.getUsers().size());
 
     }
+    Event setUp() {
+        return eventRepository.save(Event.builder()
+                .title("테스트 이벤트")
+                .category(EventCategory.BOOTCAMP_CLUB)
+                .status(EventStatus.PUBLISHED)
+                .isFree(true)
+                .isOnline(true)
+                .recruitStart(LocalDateTime.now().minusDays(20))
+                .recruitEnd(LocalDateTime.now().plusDays(500))
+                .eventStart(LocalDateTime.now().minusDays(20))
+                .eventEnd(LocalDateTime.now().plusDays(20))
+                        .targetRoles(Set.of(role, role1))
+                .hashTags(
+                        null
+                )
+                .build());
+    }
+
+    void setUpEa(String actorId, Event event, ActionType actionType){
+         eventActionRepository.save(
+                EventAction.builder()
+                        .actorId(actorId)
+                        .actorType(ActorType.USER)
+                        .event(event)
+                        .actionType(actionType)
+                        .build()
+        );
+    }
+
+
 
     @Test
     public void getUsersDetail_Success()
@@ -186,5 +232,40 @@ public class adminServiceTest
                 () -> adminService.getUsersDetail(6L)
         );
     }
+
+    @Test
+    public void getEventActionAnalytics_Success() throws NoSuchFieldException, IllegalAccessException {
+        List<Event> events = new ArrayList<>();
+        for(int i=0; i<10;i++)
+            events.add(setUp());
+        for(int i=0;i<3;i++)
+        {
+            for(int j=1;j<=5;j++)
+            {
+                String actorId = j +"L";
+                for(int k=0;k<10;k++)
+                {
+                    setUpEa(actorId,events.get(k),ActionType.values()[i % 3]);
+                }
+            }
+        }
+
+        AdminResponse.eventActionAnalyticsResponse response1=adminService.getUserEventActionAnalytics("1L","VIEW");
+        for(AdminResponse.eventActionMonthlyCountResponse a :response1.getEventActionMonthlyCountResponses())
+        {
+            System.out.println(a.getMonthLabels());
+            System.out.println(a.getOthersMonthlyCount());
+            System.out.println(a.getUserMonthlyCount());
+        }
+        for(AdminResponse.rolePercentageResponse a: response1.getRolePercentageResponses())
+        {
+            System.out.println(a.getRole());
+            System.out.println(a.getPercentage());
+        }
+
+
+
+    }
+
 
 }

--- a/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/admin/service/adminServiceTest.java
@@ -8,6 +8,7 @@ import com.example.skillup.domain.oauth.Entity.SocialLoginType;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.domain.user.enums.UserStatus;
+import com.example.skillup.domain.user.exception.UserException;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.common.BaseEntity;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 @SpringBootTest
@@ -160,6 +162,29 @@ public class adminServiceTest
         assertThat(1
         ).isEqualTo(response2.getUsers().size());
 
+    }
+
+    @Test
+    public void getUsersDetail_Success()
+    {
+        UserResponse.AdminUserDetailPageResponse response1 = adminService.getUsersDetail(1L);
+
+            System.out.println(response1.getRole());
+            System.out.println(response1.getEmail());
+            System.out.println(response1.getName());
+            System.out.println(response1.getCreatedAt());
+            System.out.println(response1.getLastLoginAt());
+            System.out.println(response1.getSocialLoginType());
+
+    }
+
+    @Test
+    public void getUsersDetail_Fail()
+    {
+        assertThrows(
+                UserException.class,
+                () -> adminService.getUsersDetail(6L)
+        );
     }
 
 }

--- a/src/test/java/com/example/skillup/domain/oauth/GoogleOauthTest.java
+++ b/src/test/java/com/example/skillup/domain/oauth/GoogleOauthTest.java
@@ -3,7 +3,7 @@ package com.example.skillup.domain.oauth;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-import com.example.skillup.domain.oauth.component.HttpClientHelper;
+import com.example.skillup.global.component.HttpClientHelper;
 import com.example.skillup.domain.oauth.dto.OauthInfoRequest;
 import com.example.skillup.global.auth.oauth.component.GoogleOauth;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/example/skillup/domain/oauth/KakaoOauthTest.java
+++ b/src/test/java/com/example/skillup/domain/oauth/KakaoOauthTest.java
@@ -3,7 +3,7 @@ package com.example.skillup.domain.oauth;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-import com.example.skillup.domain.oauth.component.HttpClientHelper;
+import com.example.skillup.global.component.HttpClientHelper;
 import com.example.skillup.domain.oauth.dto.OauthInfoRequest;
 import com.example.skillup.global.auth.oauth.component.KakaoOauth;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/example/skillup/domain/oauth/component/HttpClientHelperTest.java
+++ b/src/test/java/com/example/skillup/domain/oauth/component/HttpClientHelperTest.java
@@ -1,6 +1,7 @@
 package com.example.skillup.domain.oauth.component;
 
 import com.example.skillup.domain.oauth.exception.OauthException;
+import com.example.skillup.global.component.HttpClientHelper;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

Admin 회원관리

- 유저 목록 
<img width="437" height="578" alt="image" src="https://github.com/user-attachments/assets/21b061c3-402c-49ce-8255-ec982c8f0930" />

**탈퇴 유무 필터(deleted)와 유저 이름/이메일(keyWard) 기반 검색으로 유저 목록 조회 API 추가**
조회된 유저를 역할(개발 / 디자인 / 기획) 기준으로 분류하여 응답
전체 유저 수 및 역할별 유저 수를 함께 반환하여 관리자 페이지에서 바로 활용 가능하도록 구성

- 유저 상세보기

유저 상세보기 영역은 화면 구성과 UX 흐름에 맞춰 3개의 API로 분리하여 구현했습니다.
<img width="683" height="422" alt="image" src="https://github.com/user-attachments/assets/89cf2542-94f2-4f10-83b8-c4bc0e4d1ef8" />

**유저 기본 정보 조회 API**
유저 이름, 이메일, 가입일, 소셜 로그인 타입, 역할, 최근 로그인 시간 조회
페이지 진입 시 최초 1회 호출되는 API

**유저 활동 내역 카운트 조회 API**
VIEW / SAVE / APPLY 액션 횟수 제공
새로고침 버튼을 통해 반복 호출될 수 있어, 별도 API로 분리

**유저 활동 내역 분석(Analytics) API**
최근 6개월 기준 월별 활동 횟수 조회
특정 유저의 활동과 전체 유저 평균 활동을 비교할 수 있도록 데이터 제공
액션 타입별로 다른 데이터를 제공해야 하므로 별도 API로 분리


**👉 각 영역의 갱신 주기와 사용 목적이 달라,불필요한 재호출을 줄이기 위해 API를 분리했습니다.**


**📌 추가 변경 사항**
SocialLoginType에 한글 명칭 추가
Users ↔ TargetRole 관계를 ManyToOne으로 수정
공통 날짜/역할 변환 로직을 CommonMapper로 분리
사용자 관련 에러 코드(UserErrorCode) 추가
이벤트 도메인 데이터 변환 로직 Mapper로 이동





## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
