### PR TITLE
[HOTFIX] : 일라스틱 서치 동의어 사전 방식 변경

### DIFF
--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -9,41 +9,41 @@ import com.example.skillup.domain.admin.exception.AdminException;
 import com.example.skillup.domain.admin.mapper.AdminMapper;
 import com.example.skillup.domain.admin.mapper.SynonymMapper;
 import com.example.skillup.domain.admin.repository.AdminRepository;
-import com.example.skillup.domain.event.entity.TargetRole;
-import com.example.skillup.domain.event.enums.ActionType;
 import com.example.skillup.domain.event.repository.EventActionRepository;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Users;
-import com.example.skillup.domain.user.exception.UserErrorCode;
-import com.example.skillup.domain.user.exception.UserException;
 import com.example.skillup.domain.user.mappers.UserMapper;
 import com.example.skillup.domain.user.repository.UserRepository;
-import com.example.skillup.global.aop.ConvertNotFound;
 import com.example.skillup.global.common.BaseEntity;
 import com.example.skillup.global.component.Calculator;
 import com.example.skillup.global.exception.CommonErrorCode;
 import com.example.skillup.global.exception.GlobalException;
 import com.example.skillup.global.search.component.ElasticsearchAdminClient;
 import com.example.skillup.global.search.component.SynonymExporter;
+import com.example.skillup.global.search.dto.SynonymsSetRequest;
 import com.example.skillup.global.search.entity.SynonymGroup;
 import com.example.skillup.global.search.entity.SynonymTerm;
 import com.example.skillup.global.search.enums.SynonymStatus;
 import com.example.skillup.global.search.repository.SynonymGroupRepository;
 import com.example.skillup.global.search.repository.SynonymTermRepository;
-import java.nio.file.Path;
+import com.example.skillup.global.service.NotFoundGuardService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.util.*;
-
-import com.example.skillup.global.service.NotFoundGuardService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -57,7 +57,7 @@ public class AdminService {
     private final SynonymTermRepository synonymTermRepository;
     private final UserRepository userRepository;
     private final AdminMapper adminMapper;
-    private final UserMapper  userMapper;
+    private final UserMapper userMapper;
     private final EventActionRepository eventActionRepository;
     private final NotFoundGuardService notFoundGuardService;
 
@@ -76,10 +76,12 @@ public class AdminService {
 
     @Transactional
     public String publish(String locale) {
-        Path file = synonymExporter.exportActiveToFile(locale);
-        String reload = elasticsearchAdminClient.reloadSearchAnalyzers();
-        return file.toString() + reload;
-        //new PublishResult(true, file.toString(), reload);
+        List<SynonymsSetRequest.SynonymsRule> rules = synonymExporter.exportActiveRules(locale);
+
+        String setId = "skillup-" + locale;
+
+        SynonymsSetRequest body = new SynonymsSetRequest(rules);
+        return elasticsearchAdminClient.upsertSynonymsSet(setId, body);
     }
 
     @Transactional
@@ -141,43 +143,40 @@ public class AdminService {
         return deletedTerms;
     }
 
-    public AdminResponse.AdminUserPageResponse getUsersBySearch(String keyWard, boolean deleted,int page)
-    {
+    public AdminResponse.AdminUserPageResponse getUsersBySearch(String keyWard, boolean deleted, int page) {
         Pageable pageable = PageRequest.of(page, 20);
-        List<Users> users= userRepository.findUsersByKeyWardAndDeleted(keyWard, deleted, pageable);
+        List<Users> users = userRepository.findUsersByKeyWardAndDeleted(keyWard, deleted, pageable);
         List<UserResponse.AdminUserResponse> adminUserResponse = new ArrayList<>();
 
-        for(Users user : users)
+        for (Users user : users) {
             adminUserResponse.add(userMapper.toAdminUserResponse(user));
+        }
 
         return adminMapper.toAdminUserPageResponse(adminUserResponse, pageable, page,
-        users.size());
+                users.size());
 
     }
 
 
-    public UserResponse.AdminUserDetailPageResponse getUsersDetail(Long userId)
-    {
+    public UserResponse.AdminUserDetailPageResponse getUsersDetail(Long userId) {
         return userMapper.toAdminUserDetailPageResponse(notFoundGuardService.getUsersNative(userId));
     }
 
-    public UserResponse.AdminUserEventActionCountsResponse getUserActionCounts(String actorId)
-    {
+    public UserResponse.AdminUserEventActionCountsResponse getUserActionCounts(String actorId) {
         UserRepository.EventActionCountProjection usersActionCounts = userRepository.getUserActionCounts(actorId);
         return userMapper.toAdminUserEventActionResponse(usersActionCounts.getViewCnt()
-                ,usersActionCounts.getSaveCnt(),usersActionCounts.getApplyCnt());
+                , usersActionCounts.getSaveCnt(), usersActionCounts.getApplyCnt());
     }
 
     @Transactional(readOnly = true)
-    public AdminResponse.eventActionAnalyticsResponse getUserEventActionAnalytics(String userId,String actionType)
-    {
+    public AdminResponse.eventActionAnalyticsResponse getUserEventActionAnalytics(String userId, String actionType) {
         LocalDateTime since = LocalDate.now()
                 .withDayOfMonth(1)
                 .minusMonths(5)
                 .atStartOfDay();
 
         List<EventActionRepository.EventActionAnalyticsProjection> eventActionAnalytics
-                =  eventActionRepository.findEventActionsBySinceAndActionType(since, actionType);
+                = eventActionRepository.findEventActionsBySinceAndActionType(since, actionType);
 
         List<EventActionRepository.EventActionAnalyticsProjection> usersEventActionAnalytics =
                 eventActionAnalytics.stream()
@@ -189,15 +188,14 @@ public class AdminService {
                         .filter(a -> !Objects.equals(a.getActorId(), userId))
                         .toList();
 
-
-
-
         Map<String, Integer> roleCountMap = new HashMap<>();
         int totalRoleCount = 0;
 
         for (EventActionRepository.EventActionAnalyticsProjection action : usersEventActionAnalytics) {
             String roles = action.getTargetRoles();
-            if (roles == null || roles.isBlank()) continue;
+            if (roles == null || roles.isBlank()) {
+                continue;
+            }
 
             for (String roleName : roles.split(",")) {
                 roleCountMap.merge(roleName, 1, Integer::sum);
@@ -214,18 +212,20 @@ public class AdminService {
         Map<YearMonth, Integer> userMonthlyCountMap =
                 Calculator.countByMonth(usersEventActionAnalytics);
 
-        Map<YearMonth, Integer> othersMonthlyCountMap  =
+        Map<YearMonth, Integer> othersMonthlyCountMap =
                 Calculator.countByMonth(othersEventActionAnalytics);
 
         int totalUserCount = userRepository.getTotalCount();
 
         othersMonthlyCountMap.replaceAll((month, count) -> {
-            if (totalUserCount == 0) return 0;
+            if (totalUserCount == 0) {
+                return 0;
+            }
             return count / totalUserCount;
         });
 
-
-        return adminMapper.toEventActionAnalyticsResponse(rolePercentageMap,userMonthlyCountMap,othersMonthlyCountMap,since);
+        return adminMapper.toEventActionAnalyticsResponse(rolePercentageMap, userMonthlyCountMap, othersMonthlyCountMap,
+                since);
 
     }
 }

--- a/src/main/java/com/example/skillup/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/example/skillup/global/exception/CommonErrorCode.java
@@ -21,6 +21,7 @@ public enum CommonErrorCode implements ResultCode {
     INVALID_FILE_TYPE("INVALID_FILE_TYPE", "지원하지 않는 파일 확장자 입니다.(jpg , png 만 가능합니다.)", HttpStatus.BAD_REQUEST),
     FILE_SIZE_EXCEED("FILE_SIZE_EXCEED", "파일 크기가 제한을 초과했습니다.", HttpStatus.BAD_REQUEST),
     FILE_DELETE_ERROR("FILE_DELETE_ERROR" , "파일 삭제중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),
+    ELASTICSEARCH_ERROR("ELASTICSEARCH_ERROR" , "일라스틱 서치 업로드 중 오류가 발생했습니다." , HttpStatus.BAD_GATEWAY),
     ;
 
 

--- a/src/main/java/com/example/skillup/global/search/component/ElasticsearchAdminClient.java
+++ b/src/main/java/com/example/skillup/global/search/component/ElasticsearchAdminClient.java
@@ -1,27 +1,37 @@
 package com.example.skillup.global.search.component;
 
 import com.example.skillup.global.exception.CommonErrorCode;
+import com.example.skillup.global.search.dto.SynonymsSetRequest;
 import com.example.skillup.global.search.exception.SearchException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ElasticsearchAdminClient {
 
     private final org.elasticsearch.client.RestClient low;
+    private final ObjectMapper objectMapper;
 
-    @Value("${skillup.search.index-name}")
-    private String index;
-
-    public String reloadSearchAnalyzers() {
+    public String upsertSynonymsSet(String setId, SynonymsSetRequest requestBody) {
         try {
-            var req = new org.elasticsearch.client.Request("POST", "/" + index + "/_reload_search_analyzers");
-            var res = low.performRequest(req);
-            return org.apache.http.util.EntityUtils.toString(res.getEntity());
+            Request req = new Request("PUT", "/_synonyms/" + setId);
+            req.setJsonEntity(objectMapper.writeValueAsString(requestBody));
+
+            Response res = low.performRequest(req);
+
+            return EntityUtils.toString(res.getEntity());
         } catch (Exception e) {
-            throw new SearchException(CommonErrorCode.FILE_UPLOAD_ERROR, "ES 분석기 재로드 실패: " + e.getMessage());
+            throw new SearchException(
+                    CommonErrorCode.ELASTICSEARCH_ERROR,
+                    "ES synonyms set 업데이트 실패(setId=" + setId + "): " + e.getMessage()
+            );
         }
     }
 

--- a/src/main/java/com/example/skillup/global/search/component/SynonymExporter.java
+++ b/src/main/java/com/example/skillup/global/search/component/SynonymExporter.java
@@ -1,23 +1,15 @@
 package com.example.skillup.global.search.component;
 
 
+import com.example.skillup.global.search.dto.SynonymsSetRequest;
 import com.example.skillup.global.search.entity.SynonymGroup;
 import com.example.skillup.global.search.enums.SynonymStatus;
-import com.example.skillup.global.search.exception.SearchException;
 import com.example.skillup.global.search.repository.SynonymGroupRepository;
 import com.example.skillup.global.search.repository.SynonymTermRepository;
-import com.example.skillup.global.exception.CommonErrorCode;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,32 +20,29 @@ public class SynonymExporter {
     private final SynonymGroupRepository synonymGroupRepository;
     private final SynonymTermRepository synonymTermRepository;
 
-    @Value("${skillup.synonyms.export-dir}") private String exportDir;
-    @Value("${skillup.synonyms.file-name}") private String fileName;
-
     @Transactional(readOnly = true)
-    public Path exportActiveToFile(String locale) {
-        List<SynonymGroup> groups = synonymGroupRepository.findSynonymGroupByStatusAndLocale(SynonymStatus.ACTIVE , locale);
-        Map<Long, List<String>> termsByGroup = synonymTermRepository.findAllActiveGrouped(locale);
+    public List<SynonymsSetRequest.SynonymsRule> exportActiveRules(String locale) {
+        List<SynonymGroup> groups =
+                synonymGroupRepository.findSynonymGroupByStatusAndLocale(SynonymStatus.ACTIVE, locale);
 
-        List<String> lines = new ArrayList<>();
+        Map<Long, List<String>> termsByGroup =
+                synonymTermRepository.findAllActiveGrouped(locale);
+
+        List<SynonymsSetRequest.SynonymsRule> rules = new ArrayList<>();
+
         for (SynonymGroup g : groups) {
-            List<String> terms = termsByGroup.getOrDefault(g.getId(), List.of());
-            if (!terms.isEmpty()) {
-                lines.add(String.join(", ", terms));
-            }
+            List<String> terms = termsByGroup.getOrDefault(g.getId(), List.of()).stream()
+                    .map(String::trim)
+                    .filter(s -> !s.isBlank())
+                    .distinct()
+                    .toList();
+
+            String synonymsSolr = String.join(", ", terms);
+            String ruleId = "g-" + g.getId();
+
+            rules.add(new SynonymsSetRequest.SynonymsRule(ruleId, synonymsSolr));
         }
 
-        Path path = Paths.get(exportDir, fileName);
-        try {
-            Files.createDirectories(path.getParent());
-            Files.write(path, lines, StandardCharsets.UTF_8,
-                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-            return path;
-        } catch (IOException e) {
-            throw new SearchException(CommonErrorCode.FILE_UPLOAD_ERROR, "동의어 파일 생성 실패: " + e.getMessage());
-        }
+        return rules;
     }
-
-
 }

--- a/src/main/java/com/example/skillup/global/search/dto/SynonymsSetRequest.java
+++ b/src/main/java/com/example/skillup/global/search/dto/SynonymsSetRequest.java
@@ -1,0 +1,7 @@
+package com.example.skillup.global.search.dto;
+
+import java.util.List;
+
+public record SynonymsSetRequest(List<SynonymsRule> synonyms_set) {
+    public record SynonymsRule(String id, String synonyms) {}
+}

--- a/src/main/java/com/example/skillup/global/search/entity/SynonymTerm.java
+++ b/src/main/java/com/example/skillup/global/search/entity/SynonymTerm.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -26,7 +27,7 @@ import org.hibernate.annotations.SQLRestriction;
 public class SynonymTerm extends BaseEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/example/skillup/global/search/service/EventSearchService.java
+++ b/src/main/java/com/example/skillup/global/search/service/EventSearchService.java
@@ -26,12 +26,14 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EventSearchService {
 
     @Value("${skillup.search.index-name}")
@@ -142,6 +144,7 @@ public class EventSearchService {
                 documentSearchResponse.hits().total() == null ? 0 : (int) documentSearchResponse.hits().total().value();
 
         if (total == 0) {
+            log.info("검색 결과가 0개입니다.");
             var rows = eventRepository.findPopularForHomeWithPopularity(
                     null,
                     since,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ skillup:
     export-dir: src/main/resources/es-synonyms   # ES 컨테이너 마운트 경로
     file-name: synonyms_ko.txt
   search:
-    index-name: events_v2
+    index-name: events_v3
 
 spring:
   profiles:


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

- Elasticsearch 8.x의 **Synonyms API(`synonyms_set`)** 를 사용하면 파일 없이 ES 내부 리소스로 동의어를 관리할 수 있어, 환경 분리에서도 동일한 방식으로 안정적으로 운영 가능해서 해당 방식으로 수정했습니다.
- seed.sql 에 동의어 사전 목업 데이터 추가했습니다.

## 변경 내용 (How)
### 1) publish 흐름 변경: 파일 export 제거
- 기존: DB 조회 → 동의어 파일 export → (분석기 재로드)
- 변경: DB 조회 → Synonyms API 업서트 (`PUT /_synonyms/{setId}`)
- dto 추가했습니다.
## 2) 책임 분리
- **SynonymExporter**: DB에서 `ACTIVE` 동의어 그룹/텀을 조회하여 **Synonyms API 규격(`rules`) 생성**
- **ElasticsearchAdminClient**: `PUT /_synonyms/{setId}` 호출로 **동의어 세트 업서트(upsert)**

## 3) 반영 방식
- **Synonyms API(`synonyms_set`)** 기반으로 업로드되므로, 파일 기반과 달리 **별도 파일 배포/마운트 없이** ES 내부 리소스로 동의어가 관리됩니다.


## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
