### PR TITLE
[FEAT] : 홈화면 행사 목록 조회 API 추가 및 행사 검색 API GET->POST 로 변경

### DIFF
--- a/src/main/java/com/example/skillup/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/example/skillup/domain/article/controller/ArticleController.java
@@ -100,14 +100,22 @@ public class ArticleController {
         return BaseResponse.success("배너 수정 성공", articleService.updateAdminArticle(articleId, request, thumbnailImage));
     }
 
-    @GetMapping()
+    @GetMapping("/search")
     @Operation(summary = "아티클 목록 조회 및 검색 API", description = "일반 회원의 아티클 목록 조회 및 검색 API 입니다. 직군을 입력해주세요 (기획자/디자이너/개발자/AI 개발자)")
-    public BaseResponse<ArticleResponse.HomeArticleResponseList> GetArticlesDetail(
+    public BaseResponse<ArticleResponse.HomeArticleResponseList> getArticlesDetail(
             @RequestParam(defaultValue = "") String keyword,
             @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(required = false) List<String> tab
     ) {
         return BaseResponse.success("아티클 목록 조회 성공.", articleService.getHomeArticle(tab, page, keyword));
+    }
+
+    @GetMapping()
+    @Operation(summary = "홈화면에서의 아티클 조회 API" , description = "홈화면 아티클 목록 조회 API 입니다. , 직군을 입력해주세요 (기획/디자인/개발/AI)")
+    public BaseResponse<List<ArticleResponse.HomeArticleResponse>> getFeaturedArticles(
+            @RequestParam(defaultValue = "전체") String tab
+    ){
+        return BaseResponse.success("홈화면 아티클 목록 조회 성공" , articleService.getFeaturedArticles(tab));
     }
 
     @PostMapping("/read/{articleId}")

--- a/src/main/java/com/example/skillup/domain/article/dto/response/ArticleResponse.java
+++ b/src/main/java/com/example/skillup/domain/article/dto/response/ArticleResponse.java
@@ -1,6 +1,7 @@
 package com.example.skillup.domain.article.dto.response;
 
 import com.example.skillup.domain.article.enums.ArticleStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -68,6 +69,7 @@ public class ArticleResponse {
     @AllArgsConstructor
     @Getter
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class HomeArticleResponse {
         private String title;
         private String summary;

--- a/src/main/java/com/example/skillup/domain/article/mapper/ArticleMapper.java
+++ b/src/main/java/com/example/skillup/domain/article/mapper/ArticleMapper.java
@@ -107,4 +107,15 @@ public class ArticleMapper {
                 .totalPages(totalPages)
                 .build();
     }
+
+    public List<HomeArticleResponse> toFeaturedArticleResponse(List<Article> articles) {
+        return articles.stream().map(article -> HomeArticleResponse.builder()
+                .title(article.getTitle())
+                .summary(article.getSummary())
+                .source(article.getSource())
+                .originalPublishedDate(article.getOriginalPublishedDate())
+                .thumbnailUrl(article.getThumbnailUrl())
+                .originalUrl(article.getOriginalUrl())
+                .build()).toList();
+    }
 }

--- a/src/main/java/com/example/skillup/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/skillup/domain/article/repository/ArticleRepository.java
@@ -78,4 +78,17 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             @Param("roleCount") int roleCount,
             Pageable pageable
     );
+
+
+    @Query("""
+            select distinct a
+            from Article a
+            join a.targetRoles tr
+            where a.status = :status
+              and tr.name = :roleName
+            order by a.originalPublishedDate desc
+            """)
+    List<Article> findLatestByRole(ArticleStatus status, String roleName, Pageable pageable);
+
+    List<Article> findTop5ByStatusOrderByOriginalPublishedDateDesc(ArticleStatus articleStatus);
 }

--- a/src/main/java/com/example/skillup/domain/article/service/ArticleService.java
+++ b/src/main/java/com/example/skillup/domain/article/service/ArticleService.java
@@ -3,6 +3,7 @@ package com.example.skillup.domain.article.service;
 import com.example.skillup.domain.article.dto.request.ArticleRequest;
 import com.example.skillup.domain.article.dto.response.ArticleResponse;
 import com.example.skillup.domain.article.dto.response.ArticleResponse.CommonArticleResponse;
+import com.example.skillup.domain.article.dto.response.ArticleResponse.HomeArticleResponse;
 import com.example.skillup.domain.article.entity.Article;
 import com.example.skillup.domain.article.enums.ArticleStatus;
 import com.example.skillup.domain.article.exception.ArticleErrorCode;
@@ -10,9 +11,7 @@ import com.example.skillup.domain.article.exception.ArticleException;
 import com.example.skillup.domain.article.mapper.ArticleMapper;
 import com.example.skillup.domain.article.repository.ArticleRepository;
 import com.example.skillup.domain.event.entity.TargetRole;
-import com.example.skillup.domain.event.exception.TargetRoleErrorCode;
-import com.example.skillup.domain.event.repository.TargetRoleRepository;
-import com.example.skillup.global.aop.ConvertNotFound;
+import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.service.NotFoundGuardService;
 import com.example.skillup.global.service.S3Service;
 import java.util.List;
@@ -36,7 +35,6 @@ public class ArticleService {
     private final NotFoundGuardService notFoundGuardService;
 
     private static final Set<String> ALLOWED_SORTS = Set.of("게시일순", "등록일순");
-
 
 
     @Transactional
@@ -158,5 +156,20 @@ public class ArticleService {
         article.increaseClickCount();
 
         return article.getClickCount();
+    }
+
+    @Transactional(readOnly = true)
+    public List<HomeArticleResponse> getFeaturedArticles(String tab) {
+        String roleName = CommonMapper.resolveRoleName(tab);
+        List<Article> articles;
+        if (roleName == null) {
+            articles = articleRepository.findTop5ByStatusOrderByOriginalPublishedDateDesc(ArticleStatus.PUBLISHED);
+            return articleMapper.toFeaturedArticleResponse(articles);
+        }
+
+        Pageable pageable = PageRequest.of(0, 5);
+        articles = articleRepository.findLatestByRole(ArticleStatus.PUBLISHED, roleName, pageable);
+
+        return articleMapper.toFeaturedArticleResponse(articles);
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -28,7 +28,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -271,12 +270,11 @@ public class EventController {
         return BaseResponse.success("홈 화면에서 최근 본 이벤트 조회 성공", events);
     }
 
-    @GetMapping("/search/home")
+    @PostMapping("/search/home")
     @Operation(summary = "행사 검색 api", description = "검색 내용의 행사들을 불러옵니다.")
     public BaseResponse<EventResponse.SearchEventResponseList> searchEvents(
-            @Valid @ModelAttribute EventRequest.EventSearchRequest request) {
+            @Valid @RequestBody EventRequest.EventSearchRequest request) {
         return BaseResponse.success("검색 성공", eventSearchService.search(request));
-
     }
 
     @PatchMapping("/{eventId}/apply")

--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -163,6 +163,7 @@ public class EventRequest {
         @NotNull(message = "검색어를 입력해주세요")
         private String searchString;
 
+        @Builder.Default
         private EventSortType sort = EventSortType.POPULARITY;
 
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
@@ -176,7 +177,7 @@ public class EventRequest {
         private Boolean isFree;
 
         @NotNull(message = "페이지 번호를 입력해주세요. (페이지당 게시글은 12개)")
-        private Integer page = 0;
+        private Integer page;
 
     }
 

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -2,7 +2,6 @@ package com.example.skillup.domain.event.service;
 
 import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.dto.response.EventResponse;
-import com.example.skillup.domain.event.dto.response.EventResponse.EventApplyResponse;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventAction;
 import com.example.skillup.domain.event.entity.EventLike;
@@ -14,26 +13,17 @@ import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventStatus;
 import com.example.skillup.domain.event.exception.EventErrorCode;
 import com.example.skillup.domain.event.exception.EventException;
-import com.example.skillup.domain.event.exception.HashTagErrorCode;
-import com.example.skillup.domain.event.exception.TargetRoleErrorCode;
 import com.example.skillup.domain.event.mapper.EventMapper;
 import com.example.skillup.domain.event.repository.EventActionRepository;
-import com.example.skillup.domain.event.repository.EventBannerRepository;
 import com.example.skillup.domain.event.repository.EventLikeRepository;
 import com.example.skillup.domain.event.repository.EventRepository;
 import com.example.skillup.domain.event.repository.EventRepositoryImpl;
-import com.example.skillup.domain.event.repository.EventViewDailyRepository;
-import com.example.skillup.domain.event.repository.HashTagRepository;
-import com.example.skillup.domain.event.repository.TargetRoleRepository;
 import com.example.skillup.domain.user.entity.Guest;
 import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.domain.user.entity.UsersDetails;
 import com.example.skillup.domain.user.repository.GuestRepository;
-import com.example.skillup.domain.user.repository.UserRepository;
-import com.example.skillup.global.aop.ConvertNotFound;
 import com.example.skillup.global.aop.HandleDataAccessException;
 import com.example.skillup.global.common.CommonMapper;
-import com.example.skillup.global.common.CommonResponse;
 import com.example.skillup.global.exception.CommonErrorCode;
 import com.example.skillup.global.search.service.EventIndexerService;
 import com.example.skillup.global.service.NotFoundGuardService;
@@ -97,8 +87,6 @@ public class EventService {
 
     @Value("${event.popularity.recommend-threshold:70}")
     private double recommendThreshold;
-
-
 
 
     @Transactional
@@ -271,7 +259,7 @@ public class EventService {
 
     @Transactional(readOnly = true)
     public EventResponse.featuredEventResponseList getFeaturedEvents(String tab, int size) {
-        String roleName = resolveRoleName(tab);
+        String roleName = CommonMapper.resolveRoleName(tab);
         String roleFilter = null;
 
         if (roleName != null) {
@@ -355,19 +343,6 @@ public class EventService {
         return views * 0.6 + likes * 0.3 + ctr * 0.1;
     }
 
-    private String resolveRoleName(String tab) {
-        if (tab == null || tab.isBlank() || "IT 전체".equals(tab)) {
-            return null;
-        }
-        return switch (tab) {
-            case "기획" -> "기획자";
-            case "디자인" -> "디자이너";
-            case "개발" -> "개발자";
-            case "AI" -> "AI 개발자";
-            default -> null;
-        };
-    }
-
     @Transactional
     public void toggleLike(Event event, Users users) {
         if (eventLikeRepository.existsByEventIdAndUserId(event.getId(), users.getId())) {
@@ -394,8 +369,8 @@ public class EventService {
                 now,
                 targetRoleCount,
                 targetRolesIsEmpty);
-      
-        return eventMapper.toCategoryPageEventResponseListWithPageable(events,pageable,condition.getPage(),count);
+
+        return eventMapper.toCategoryPageEventResponseListWithPageable(events, pageable, condition.getPage(), count);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/skillup/global/common/CommonMapper.java
+++ b/src/main/java/com/example/skillup/global/common/CommonMapper.java
@@ -1,16 +1,11 @@
 package com.example.skillup.global.common;
 
-import com.example.skillup.domain.event.entity.TargetRole;
-import com.example.skillup.domain.user.dto.response.UserResponse;
-import com.example.skillup.domain.user.entity.Users;
-import org.springframework.data.domain.Pageable;
-
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import org.springframework.data.domain.Pageable;
 
 public class CommonMapper {
-    public static String toDatePattern(LocalDateTime dateTime)
-    {
+    public static String toDatePattern(LocalDateTime dateTime) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
         return dateTime.format(formatter);
     }
@@ -19,16 +14,28 @@ public class CommonMapper {
         return switch (role) {
             case "개발자" -> "개발";
             case "디자이너" -> "디자인";
-            default ->  "기획";
+            default -> "기획";
+        };
+    }
+
+    public static String resolveRoleName(String tab) {
+        if (tab == null || tab.isBlank() || "IT 전체".equals(tab) || tab.equals("전체")) {
+            return null;
+        }
+        return switch (tab) {
+            case "기획" -> "기획자";
+            case "디자인" -> "디자이너";
+            case "개발" -> "개발자";
+            case "AI" -> "AI 개발자";
+            default -> null;
         };
     }
 
     public static CommonResponse.PageInfoResponse toPageInfoResponse
-            (Pageable pageable, int page,int count)
-    {
+            (Pageable pageable, int page, int count) {
         return CommonResponse.PageInfoResponse
                 .builder()
-                .currentPage(page+1)
+                .currentPage(page + 1)
                 .pageSize(pageable.getPageSize())
                 .totalPages((int) Math.ceil((double) count / (pageable.getPageSize())))
                 .build();

--- a/src/main/java/com/example/skillup/global/config/SampleDataLoader.java
+++ b/src/main/java/com/example/skillup/global/config/SampleDataLoader.java
@@ -3,6 +3,9 @@ package com.example.skillup.global.config;
 import com.example.skillup.domain.admin.entity.Admin;
 import com.example.skillup.domain.admin.enums.AdminRole;
 import com.example.skillup.domain.admin.repository.AdminRepository;
+import com.example.skillup.domain.article.entity.Article;
+import com.example.skillup.domain.article.enums.ArticleStatus;
+import com.example.skillup.domain.article.repository.ArticleRepository;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventBanner;
 import com.example.skillup.domain.event.entity.EventLike;
@@ -52,6 +55,7 @@ public class SampleDataLoader implements CommandLineRunner {
     private final SynonymTermRepository synonymTermRepository;
     private final HashTagRepository hashTagRepository;
     private final EventBannerRepository eventBannerRepository;
+    private final ArticleRepository articleRepository;
 
     @Override
     @Transactional
@@ -62,7 +66,7 @@ public class SampleDataLoader implements CommandLineRunner {
         TargetRole planner = getOrCreateRole("기획자");
         TargetRole targetRoleTest = getOrCreateRole("string");
 
-        targetRoleRepository.saveAll(List.of(dev, design, planner , targetRoleTest));
+        targetRoleRepository.saveAll(List.of(dev, design, planner, targetRoleTest));
 
         HashTag hashTagTest = getOrCreateHashTag("string");
 
@@ -237,7 +241,6 @@ public class SampleDataLoader implements CommandLineRunner {
         makeSynonyms("ko", "우테코 관련 동의어", List.of("우테코", "우아한테크코스", "woowacourse"));
         makeSynonyms("ko", "IT 기업 관련 동의어", List.of("네카라쿠배", "네이버", "카카오", "라인", "쿠팡"));
 
-
         // === 5) 배너 더미 데이터 ===
         LocalDate today = now.toLocalDate();
 
@@ -323,6 +326,82 @@ public class SampleDataLoader implements CommandLineRunner {
                 mainPastOldHackathon
         ));
 
+        // === Article 더미 데이터 ===
+        Article a1 = Article.builder()
+                .title("Spring Boot 3 성능 최적화 체크리스트")
+                .summary("JPA 페이징, 인덱스, 캐시까지 실무에서 바로 쓰는 최적화 포인트를 정리합니다.")
+                .thumbnailUrl("https://example.com/thumb/article1.jpg")
+                .originalUrl("https://example.com/articles/spring-boot-performance")
+                .status(ArticleStatus.PUBLISHED)
+                .clickCount(15L)
+                .source("SkillUp Blog")
+                .originalPublishedDate(LocalDate.now().minusDays(2))
+                .build();
+        a1.addTargetRole(dev);
+
+        Article a2 = Article.builder()
+                .title("디자이너를 위한 UX 리서치 빠른 시작")
+                .summary("문제 정의부터 가설, 인터뷰 설계까지 UX 리서치의 핵심 흐름을 소개합니다.")
+                .thumbnailUrl("https://example.com/thumb/article2.jpg")
+                .originalUrl("https://example.com/articles/ux-research")
+                .status(ArticleStatus.PUBLISHED)
+                .clickCount(7L)
+                .source("Design Weekly")
+                .originalPublishedDate(LocalDate.now().minusDays(5))
+                .build();
+        a2.addTargetRole(design);
+
+        Article a3 = Article.builder()
+                .title("서비스 기획자가 알아야 할 A/B 테스트 기본")
+                .summary("지표 설계와 실험 설계에서 자주 하는 실수를 중심으로 A/B 테스트를 설명합니다.")
+                .thumbnailUrl("https://example.com/thumb/article3.jpg")
+                .originalUrl("https://example.com/articles/ab-testing")
+                .status(ArticleStatus.PUBLISHED)
+                .clickCount(22L)
+                .source("Product Note")
+                .originalPublishedDate(LocalDate.now().minusDays(1))
+                .build();
+        a3.addTargetRole(planner);
+
+        Article a4 = Article.builder()
+                .title("ElasticSearch n-gram으로 자동완성 구현하기")
+                .summary("n-gram 토크나이저와 analyzer 조합으로 검색 자동완성을 구성하는 방법을 정리했습니다.")
+                .thumbnailUrl("https://example.com/thumb/article4.jpg")
+                .originalUrl("https://example.com/articles/es-ngram-autocomplete")
+                .status(ArticleStatus.PUBLISHED)
+                .clickCount(40L)
+                .source("Search Lab")
+                .originalPublishedDate(LocalDate.now().minusDays(3))
+                .build();
+        a4.addTargetRole(dev);
+        a4.addTargetRole(planner);
+
+        Article a5 = Article.builder()
+                .title("디자인 시스템 구축 전 체크해야 할 7가지")
+                .summary("컴포넌트 기준, 토큰, 문서화 방식 등 디자인 시스템 도입 시 핵심 포인트를 다룹니다.")
+                .thumbnailUrl("https://example.com/thumb/article5.jpg")
+                .originalUrl("https://example.com/articles/design-system")
+                .status(ArticleStatus.PUBLISHED)
+                .clickCount(5L)
+                .source("UI Archive")
+                .originalPublishedDate(LocalDate.now().minusDays(7))
+                .build();
+        a5.addTargetRole(design);
+
+        Article a6 = Article.builder()
+                .title("[DRAFT] 운영 자동화를 위한 모니터링 설계 메모")
+                .summary("CloudWatch + Lambda + SNS 기반 이상탐지 흐름을 정리 중입니다.")
+                .thumbnailUrl("https://example.com/thumb/article6.jpg")
+                .originalUrl("https://example.com/articles/monitoring-draft")
+                .status(ArticleStatus.DRAFT)
+                .clickCount(0L)
+                .source("Internal")
+                .originalPublishedDate(LocalDate.now())
+                .build();
+        a6.addTargetRole(dev);
+
+        articleRepository.saveAll(List.of(a1, a2, a3, a4, a5, a6));
+
     }
 
     private void makeSynonyms(String local, String comment, List<String> terms) {
@@ -348,7 +427,8 @@ public class SampleDataLoader implements CommandLineRunner {
 
     private HashTag getOrCreateHashTag(String name) {
         return hashTagRepository.findByName(name)
-                .orElseGet(() -> hashTagRepository.save(HashTag.builder().name(name).category(HashTagCategory.CAREER_GOAL).build()));
+                .orElseGet(() -> hashTagRepository.save(
+                        HashTag.builder().name(name).category(HashTagCategory.CAREER_GOAL).build()));
     }
 
     private void seedViews14(Event event, int minTotal, int maxTotal) {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

- 홈화면에서 행사 목록 조회 API 를 추가했습니다. 기존에 존재하던 API 하나로 부족할 거 같아서요.
정렬방식은 Figma 에 따로 존재하지 않아서 원본 아티클 작성 최신순으로 정렬했습니다.

- event 검색 API 의 설정값이 많아서 GET -> POST 로 변경했습니다.
- CommonMapper 에 resolveRoleName 를 추가했습니다.
- SampleDataLoader 에 Article 데이터 추가했습니다.




## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
