### PR TITLE
[FEAT] 행사 조회시 북마크 여부 기능 추가

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -130,9 +130,10 @@ public class EventController {
     @Operation(summary = "추천/인기 행사 리스트", description = "진행예정/진행중 행사 중 수동 추천 또는 인기점수 상위 이벤트를 직군 탭 기준으로 반환합니다.")
     public BaseResponse<EventResponse.featuredEventResponseList> getFeaturedEvents(
             @RequestParam(defaultValue = "ALL") JobGroup tab,
-            @RequestParam(defaultValue = "8") int size
+            @RequestParam(defaultValue = "8") int size,
+            @AuthenticationPrincipal(errorOnInvalidType = false) UsersDetails user
     ) {
-        return BaseResponse.success("추천/인기 행사 리스트 조회 성공", eventService.getFeaturedEvents(tab, size));
+        return BaseResponse.success("추천/인기 행사 리스트 조회 성공", eventService.getFeaturedEvents(tab, size , user));
     }
 
     @GetMapping("/home/closing-soon")
@@ -142,15 +143,11 @@ public class EventController {
     )
     public BaseResponse<EventResponse.featuredEventResponseList> getClosingSoonEvents(
             @RequestParam(defaultValue = "4") int size,
-            @AuthenticationPrincipal UsersDetails user
+            @AuthenticationPrincipal(errorOnInvalidType = false) UsersDetails user
     ) {
-        String jobGroup = (user != null && user.getUser() != null)
-                ? user.getUser().getRole().getName()
-                : null;
-
         return BaseResponse.success(
                 "곧 종료되는 행사 리스트 조회 성공",
-                eventService.getClosingSoonEvents(jobGroup, size)
+                eventService.getClosingSoonEvents(size , user)
         );
     }
 
@@ -161,9 +158,10 @@ public class EventController {
             @RequestParam(defaultValue = "BOOTCAMP_CLUB") EventCategory category,
             @RequestParam(defaultValue = "ALL") JobGroup tab,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal(errorOnInvalidType = false) UsersDetails user
     ) {
-        return BaseResponse.success("카테고리별 리스트 조회 성공", eventService.getEventsByCategoryForHome(category, page, size , tab));
+        return BaseResponse.success("카테고리별 리스트 조회 성공", eventService.getEventsByCategoryForHome(category, page, size , tab , user));
     }
 
     @GetMapping("/home/admin/banners")
@@ -231,19 +229,23 @@ public class EventController {
     @PostMapping("category-page/search")
     @Operation(summary = "행사 카테고리 페이지에서 검색하는 API(검색 조건이 많아 Json으로 보내기 위해서 Post 사용)", description = "특정 조건의 행사들을 불러옵니다.")
     public BaseResponse<EventResponse.SearchEventResponseList> getEventBySearch(
-            @Valid @RequestBody EventRequest.EventSearchCondition condition
+            @Valid @RequestBody EventRequest.EventSearchCondition condition,
+            @AuthenticationPrincipal(errorOnInvalidType = false) UsersDetails user
     ) {
-        EventResponse.SearchEventResponseList response = eventService.getEventBySearch(condition);
+        EventResponse.SearchEventResponseList response = eventService.getEventBySearch(condition , user);
         return BaseResponse.success("카테고리 페이지 검색 성공", response);
     }
+
 
     @GetMapping("category-page/recommended")
     @Operation(summary = "행사 카테고리 페이지 검색에서 이벤트가 부족할 때 다른 카테고리의 이벤트를 불러옵니다"
             , description = "카테고리 화면 이벤트 보충 api")
     public BaseResponse<List<EventResponse.HomeEventResponse>> getSupplementaryEvents(
-            @RequestParam EventCategory category) {
+            @RequestParam EventCategory category,
+            @AuthenticationPrincipal(errorOnInvalidType = false) UsersDetails user
+    ) {
 
-        List<EventResponse.HomeEventResponse> events = eventService.getSupplementaryEvents(category);
+        List<EventResponse.HomeEventResponse> events = eventService.getSupplementaryEvents(category , user);
         return BaseResponse.success("카테고리 페이지 추천 이벤트 조회 성공", events);
     }
 
@@ -252,7 +254,7 @@ public class EventController {
             , description = "홈 화면 이벤트 추천 api")
     public BaseResponse<List<EventResponse.HomeEventResponse>> getRecommendedEvents(
             @AuthenticationPrincipal UsersDetails user) {
-        List<EventResponse.HomeEventResponse> events = eventService.getRecommendedEvents(user.getUser().getId());
+        List<EventResponse.HomeEventResponse> events = eventService.getRecommendedEvents(user.getUser().getId() , user);
         return BaseResponse.success("홈 화면에서 추천 이벤트 조회 성공", events);
     }
 
@@ -269,7 +271,7 @@ public class EventController {
             cookieGuestId = request.getAttribute(GuestIdInterceptor.GUEST_ATTRIBUTE_NAME).toString();
         }
         List<EventResponse.HomeEventResponse> events =
-                eventService.getRecentEvents(user != null ? String.valueOf(user.getUser().getId()) : cookieGuestId);
+                eventService.getRecentEvents(user != null ? String.valueOf(user.getUser().getId()) : cookieGuestId , user);
         return BaseResponse.success("홈 화면에서 최근 본 이벤트 조회 성공", events);
     }
 

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -16,6 +16,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -188,7 +189,8 @@ public class EventMapper {
             List<EventRepositoryImpl.EventWithPopularity> events,
             Pageable pageable,
             int page,
-            int totalCount
+            int totalCount,
+            Set<Long> bookmarkedEventIds
     ) {
         return EventResponse.SearchEventResponseList.builder()
                 .homeEventResponseList(
@@ -196,9 +198,10 @@ public class EventMapper {
                                 .map(r -> {
                                     Event event = r.getEvent();
                                     double score = r.getPopularity();
+                                    boolean bookmarked = bookmarkedEventIds.contains(event.getId());
                                     return toFeaturedEvent(
                                             event,
-                                            false,
+                                            bookmarked,
                                             event.isRecommendedManual(),
                                             event.isAd(),
                                             score
@@ -213,29 +216,33 @@ public class EventMapper {
                 .build();
     }
 
-    public List<EventResponse.HomeEventResponse> toHomeEventResponsList(List<Event> events) {
+    public List<EventResponse.HomeEventResponse> toHomeEventResponsList(List<Event> events , Set<Long> bookmarkedEventIds) {
         return events.stream()
-                .map(event ->
-                        toFeaturedEvent(
-                                event,
-                                false,
-                                event.isRecommendedManual(),
-                                event.isAd(),
-                                null
-                        )
+                .map(event -> {
+                            boolean bookmarked = bookmarkedEventIds.contains(event.getId());
+                            return toFeaturedEvent(
+                                    event,
+                                    bookmarked,
+                                    event.isRecommendedManual(),
+                                    event.isAd(),
+                                    null
+                            );
+                        }
                 )
                 .toList();
     }
 
     public List<EventResponse.HomeEventResponse> toCategoryPageEventResponseList(
-            List<EventRepositoryImpl.EventWithPopularity> events
+            List<EventRepositoryImpl.EventWithPopularity> events,
+            Set<Long> bookmarkedEventIds
     ) {
         return events.stream()
                 .map(r -> {
                     Event event = r.getEvent();
+                    boolean bookmarked = bookmarkedEventIds.contains(event.getId());
                     return toFeaturedEvent(
                             event,
-                            false,
+                            bookmarked,
                             event.isRecommendedManual(),
                             event.isAd(),
                             r.getPopularity()

--- a/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
@@ -2,12 +2,9 @@ package com.example.skillup.domain.event.repository;
 
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventBookmark;
-import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.user.entity.Users;
-
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -37,4 +34,14 @@ public interface EventBookmarkRepository extends JpaRepository<EventBookmark, Lo
     List<Event> findEventsByUserWithDeadLine(@Param("user") Users user,
                               Pageable pageable);
 
+
+    @Query("""
+        select eb.event.id
+        from EventBookmark eb
+        where eb.user.id = :userId
+          and eb.event.id in :eventIds
+          and eb.isBookmarked = true
+    """)
+    List<Long> findBookmarkedEventIds(@Param("userId") Long userId,
+                                      @Param("eventIds") List<Long> eventIds);
 }

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -286,11 +286,7 @@ public class EventService {
     public EventResponse.featuredEventResponseList getClosingSoonEvents(int size, UsersDetails user) {
         LocalDateTime due = now.plusDays(14);
 
-        String roleName = null;
-
-        if (user != null && user.getUser() != null) {
-            roleName = userRepository.findByRoleNameByUsers(user.getUser());
-        }
+        String roleName = notFoundGuardService.getUsersNative(user.getUser().getId()).getRole().getName();
 
         List<EventRepository.PopularEventProjection> rows = eventRepository.findClosingSoonForHomeWithPopularity(
                 roleName, since, now, due, PageRequest.of(0, size)

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -14,6 +14,7 @@ import com.example.skillup.domain.event.exception.EventErrorCode;
 import com.example.skillup.domain.event.exception.EventException;
 import com.example.skillup.domain.event.mapper.EventMapper;
 import com.example.skillup.domain.event.repository.EventActionRepository;
+import com.example.skillup.domain.event.repository.EventBookmarkRepository;
 import com.example.skillup.domain.event.repository.EventLikeRepository;
 import com.example.skillup.domain.event.repository.EventRepository;
 import com.example.skillup.domain.event.repository.EventRepositoryImpl;
@@ -21,6 +22,7 @@ import com.example.skillup.domain.user.entity.Guest;
 import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.domain.user.entity.UsersDetails;
 import com.example.skillup.domain.user.repository.GuestRepository;
+import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.aop.HandleDataAccessException;
 import com.example.skillup.global.enums.JobGroup;
 import com.example.skillup.global.exception.CommonErrorCode;
@@ -30,9 +32,11 @@ import com.example.skillup.global.service.NotFoundGuardService;
 import com.example.skillup.global.service.S3Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
@@ -55,6 +59,8 @@ public class EventService {
     private final S3Service s3Service;
     private final AssociationBinder associationBinder;
     private final NotFoundGuardService notFoundGuardService;
+    private final EventBookmarkRepository eventBookmarkRepository;
+    private final UserRepository userRepository;
 
     LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
     LocalDateTime now = LocalDateTime.now();
@@ -245,7 +251,7 @@ public class EventService {
     }
 
     @Transactional(readOnly = true)
-    public EventResponse.featuredEventResponseList getFeaturedEvents(JobGroup tab, int size) {
+    public EventResponse.featuredEventResponseList getFeaturedEvents(JobGroup tab, int size, UsersDetails user) {
         String roleName = (tab == JobGroup.ALL) ? null : tab.getToKorean();
         String roleFilter = null;
 
@@ -260,14 +266,16 @@ public class EventService {
                 PageRequest.of(0, Math.max(1, size))
         );
 
-        // TODO: 북마크 여부 실제 연동 (현재 false 고정)
-        boolean bookmarked = false;
+        List<Long> EventIds = rows.stream().map(r -> r.getEvent().getId()).toList();
+
+        Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, EventIds);
 
         return eventMapper.toFeaturedEventResponseList(rows.stream()
                 .map(r -> {
                     double score = r.getPopularity();
                     Event event = r.getEvent();
                     boolean recommended = event.isRecommendedManual() || score >= recommendThreshold;
+                    boolean bookmarked = (user != null) && bookmarkedEventIds.contains(event.getId());
                     return eventMapper.toFeaturedEvent(event, bookmarked, recommended, event.isAd(), score);
                 })
                 .toList(), tab.getToKorean());
@@ -275,18 +283,29 @@ public class EventService {
 
 
     @Transactional(readOnly = true)
-    public EventResponse.featuredEventResponseList getClosingSoonEvents(String roleName, int size) {
+    public EventResponse.featuredEventResponseList getClosingSoonEvents(int size, UsersDetails user) {
         LocalDateTime due = now.plusDays(14);
+
+        String roleName = null;
+
+        if (user != null && user.getUser() != null) {
+            roleName = userRepository.findByRoleNameByUsers(user.getUser());
+        }
 
         List<EventRepository.PopularEventProjection> rows = eventRepository.findClosingSoonForHomeWithPopularity(
                 roleName, since, now, due, PageRequest.of(0, size)
         );
 
+        List<Long> eventIds = rows.stream().map(r -> r.getEvent().getId()).toList();
+
+        Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, eventIds);
+
         List<EventResponse.HomeEventResponse> items = rows.stream()
                 .map(r -> {
                     double score = r.getPopularity();
                     Event event = r.getEvent();
-                    return eventMapper.toFeaturedEvent(event, false, false, false, score);
+                    boolean bookmarked = (user != null) && bookmarkedEventIds.contains(event.getId());
+                    return eventMapper.toFeaturedEvent(event, bookmarked, false, false, score);
                 })
                 .toList();
 
@@ -296,7 +315,8 @@ public class EventService {
     @Transactional(readOnly = true)
     public EventResponse.CategoryEventResponseList getEventsByCategoryForHome(EventCategory category,
                                                                               int page,
-                                                                              int size, JobGroup tab) {
+                                                                              int size, JobGroup tab,
+                                                                              UsersDetails user) {
         Pageable pageable = PageRequest.of(page, size);
 
         List<EventRepository.PopularEventProjection> rows;
@@ -311,11 +331,15 @@ public class EventService {
                     category, since, now, due, pageable);
         }
 
+        List<Long> eventIds = rows.stream().map(r -> r.getEvent().getId()).toList();
+        Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, eventIds);
+
         List<EventResponse.HomeEventResponse> items = rows.stream()
                 .map(r -> {
                     double score = r.getPopularity();
                     Event event = r.getEvent();
-                    return eventMapper.toFeaturedEvent(event, false, false, false, score);
+                    boolean bookmarked = (user != null) && bookmarkedEventIds.contains(event.getId());
+                    return eventMapper.toFeaturedEvent(event, bookmarked, false, false, score);
                 })
                 .toList();
         return eventMapper.toCategoryEventResponseList(items, category);
@@ -334,10 +358,13 @@ public class EventService {
 
     @Transactional(readOnly = true)
     @HandleDataAccessException
-    public EventResponse.SearchEventResponseList getEventBySearch(EventRequest.EventSearchCondition condition) {
+    public EventResponse.SearchEventResponseList getEventBySearch(EventRequest.EventSearchCondition condition,
+                                                                  UsersDetails user) {
         Pageable pageable = PageRequest.of(condition.getPage(), 12);
         List<EventRepositoryImpl.EventWithPopularity> events = findByCategoryWithSearch(condition, pageable);
 
+        List<Long> eventIds = events.stream().map(r -> r.getEvent().getId()).toList();
+        Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, eventIds);
 
         JobGroup targetRole = condition.getTargetRole();
         String targetRoleKr = (targetRole == null) ? null : targetRole.getToKorean();
@@ -348,12 +375,13 @@ public class EventService {
                 now,
                 targetRolesIsEmpty);
 
-        return eventMapper.toCategoryPageEventResponseListWithPageable(events, pageable, condition.getPage(), count);
+        return eventMapper.toCategoryPageEventResponseListWithPageable(events, pageable, condition.getPage(), count,
+                bookmarkedEventIds);
     }
 
     @Transactional(readOnly = true)
     @HandleDataAccessException
-    public List<EventResponse.HomeEventResponse> getSupplementaryEvents(EventCategory category) {
+    public List<EventResponse.HomeEventResponse> getSupplementaryEvents(EventCategory category, UsersDetails user) {
 
         int MIN_COUNT = 3;
         Pageable pageable = PageRequest.of(0, 4);
@@ -378,25 +406,34 @@ public class EventService {
             }
         }
 
-        return eventMapper.toCategoryPageEventResponseList(result);
+        List<Long> eventIds = result.stream().map(r -> r.getEvent().getId()).toList();
+        Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, eventIds);
+
+        return eventMapper.toCategoryPageEventResponseList(result, bookmarkedEventIds);
     }
 
 
     @Transactional(readOnly = true)
     @HandleDataAccessException
-    public List<EventResponse.HomeEventResponse> getRecommendedEvents(Long actorId) {
+    public List<EventResponse.HomeEventResponse> getRecommendedEvents(Long actorId, UsersDetails user) {
         List<Event> events = eventRepository.findRecommendedEventForHome(actorId, since);
 
-        return eventMapper.toHomeEventResponsList(events);
+        List<Long> eventIds = events.stream().map(Event::getId).toList();
+        Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, eventIds);
+
+        return eventMapper.toHomeEventResponsList(events, bookmarkedEventIds);
     }
 
     @Transactional(readOnly = true)
     @HandleDataAccessException
-    public List<EventResponse.HomeEventResponse> getRecentEvents(String actorId) {
+    public List<EventResponse.HomeEventResponse> getRecentEvents(String actorId, UsersDetails user) {
         Pageable pageable = PageRequest.of(0, 10);
         List<Event> events = eventActionRepository.findRecentEventsByActorId(actorId, pageable);
 
-        return eventMapper.toHomeEventResponsList(events);
+        List<Long> eventIds = events.stream().map(Event::getId).toList();
+        Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, eventIds);
+
+        return eventMapper.toHomeEventResponsList(events, bookmarkedEventIds);
 
     }
 
@@ -444,4 +481,12 @@ public class EventService {
                 (condition, pageable, since, now);
     }
 
+    private Set<Long> getBookmarkedEventId(UsersDetails user, List<Long> eventIds) {
+        Set<Long> bookmarkedEventIds = new HashSet<>();
+
+        if (user != null && !eventIds.isEmpty()) {
+            bookmarkedEventIds.addAll(eventBookmarkRepository.findBookmarkedEventIds(user.getUser().getId(), eventIds));
+        }
+        return bookmarkedEventIds;
+    }
 }

--- a/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
@@ -1,62 +1,72 @@
 package com.example.skillup.domain.user.repository;
 
-import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Users;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.security.core.userdetails.User;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-public interface UserRepository extends JpaRepository<Users, Long>
-{
+public interface UserRepository extends JpaRepository<Users, Long> {
 
     Optional<Users> findByEmail(String email);
+
     Optional<Users> findBySocialId(String socialId);
 
     @Query(
             value = """
-    SELECT *
-    FROM users u
-    WHERE
-        (:deleted = true
-         OR (:deleted = false AND u.deleted_at IS NULL))
-      AND (:keyword IS NULL
-           OR u.email LIKE CONCAT('%', :keyword, '%')
-           OR u.name  LIKE CONCAT('%', :keyword, '%'))
-    ORDER BY u.created_at DESC
-    """,
+                    SELECT *
+                    FROM users u
+                    WHERE
+                        (:deleted = true
+                         OR (:deleted = false AND u.deleted_at IS NULL))
+                      AND (:keyword IS NULL
+                           OR u.email LIKE CONCAT('%', :keyword, '%')
+                           OR u.name  LIKE CONCAT('%', :keyword, '%'))
+                    ORDER BY u.created_at DESC
+                    """,
             nativeQuery = true
     )
-    List<Users> findUsersByKeyWardAndDeleted(@Param("keyWard") String keyWard, @Param("deleted") Boolean deleted,Pageable pageable);
+    List<Users> findUsersByKeyWardAndDeleted(@Param("keyWard") String keyWard, @Param("deleted") Boolean deleted,
+                                             Pageable pageable);
 
     @Query(value = """
-SELECT
-    COALESCE(SUM(ea.action_type = 'VIEW') AS viewCnt,0),
-    COALESCE(SUM(ea.action_type = 'APPLY') AS applyCnt,0),
-    COALESCE(SUM(ea.action_type = 'SAVE') AS saveCnt,0)
-FROM event_action ea
-WHERE ea.actorId = :actorId
-""", nativeQuery = true)
+            SELECT
+                COALESCE(SUM(ea.action_type = 'VIEW') AS viewCnt,0),
+                COALESCE(SUM(ea.action_type = 'APPLY') AS applyCnt,0),
+                COALESCE(SUM(ea.action_type = 'SAVE') AS saveCnt,0)
+            FROM event_action ea
+            WHERE ea.actorId = :actorId
+            """, nativeQuery = true)
     EventActionCountProjection getUserActionCounts(@Param("actorId") String actorId);
+
+    @Query(
+            value = """
+                    SELECT r.name
+                    from Users u
+                    join u.role r
+                    where u = :user
+                    """
+    )
+    String findByRoleNameByUsers(@Param("user") Users user);
 
     public interface EventActionCountProjection {
         int getViewCnt();
+
         int getApplyCnt();
+
         int getSaveCnt();
     }
-    @Query(value = """
-    SELECT COUNT(*)
-    FROM Users u
-    WHERE u.deletedAt IS NULL
-    """)
-    int getTotalCount();
 
+    @Query(value = """
+            SELECT COUNT(*)
+            FROM Users u
+            WHERE u.deletedAt IS NULL
+            """)
+    int getTotalCount();
 
 
     @Query(
@@ -66,13 +76,12 @@ WHERE ea.actorId = :actorId
     Optional<Users> findByIdNative(@Param("userId") Long userId);
 
 
-
     @Modifying
     @Query("""
-    DELETE FROM Users u
-    WHERE u.role = :guestRole
-      AND u.deletedAt IS NOT NULL
-      AND u.deletedAt <= :threshold
-""")
-    void deleteExpiredUsers( @Param("threshold") LocalDateTime threshold);
+                DELETE FROM Users u
+                WHERE u.role = :guestRole
+                  AND u.deletedAt IS NOT NULL
+                  AND u.deletedAt <= :threshold
+            """)
+    void deleteExpiredUsers(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
@@ -37,6 +37,7 @@ import com.example.skillup.domain.user.entity.UsersDetails;
 import com.example.skillup.domain.user.enums.UserStatus;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.common.BaseEntity;
+import com.example.skillup.global.enums.JobGroup;
 import com.example.skillup.global.service.NotFoundGuardService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -419,17 +420,17 @@ public class EventServiceTest {
         EventResponse.SearchEventResponseList resultByCategory
                 = eventService.getEventBySearch
                 (EventRequest.EventSearchCondition.builder().category(EventCategory.CONFERENCE_SEMINAR)
-                        .targetRole("DESIGNER").sort(EventSortType.LATEST).page(0).build());
+                        .targetRole(JobGroup.DESIGN).sort(EventSortType.LATEST).page(0).build() , null);
         EventResponse.SearchEventResponseList resultByCategory2
                 = eventService.getEventBySearch
                 (EventRequest.EventSearchCondition.builder().category(EventCategory.CONFERENCE_SEMINAR)
                         .sort(EventSortType.LATEST)
-                        .page(1).build());
+                        .page(1).build() , null);
 
         EventResponse.SearchEventResponseList resultByCategory3
                 = eventService.getEventBySearch
                 (EventRequest.EventSearchCondition.builder().category(EventCategory.CONFERENCE_SEMINAR)
-                        .targetRole("PLANNER").sort(EventSortType.LATEST).page(0).build());
+                        .targetRole(JobGroup.PM).sort(EventSortType.LATEST).page(0).build() , null);
 
         assertThat(resultByCategory).isNotNull();
         System.out.println(resultByCategory.getTotal());
@@ -563,11 +564,11 @@ public class EventServiceTest {
                 .page(0)
                 .build();
 
-        EventResponse.SearchEventResponseList resultsByPopularity = eventService.getEventBySearch(condPopularity);
+        EventResponse.SearchEventResponseList resultsByPopularity = eventService.getEventBySearch(condPopularity , null);
 
-        EventResponse.SearchEventResponseList resultsByLatest = eventService.getEventBySearch(condLatest);
+        EventResponse.SearchEventResponseList resultsByLatest = eventService.getEventBySearch(condLatest , null);
 
-        EventResponse.SearchEventResponseList resultsByDeadLine = eventService.getEventBySearch(condDeadline);
+        EventResponse.SearchEventResponseList resultsByDeadLine = eventService.getEventBySearch(condDeadline , null);
 
         // assertions
         assertThat(resultsByDeadLine).isNotNull();
@@ -597,7 +598,7 @@ public class EventServiceTest {
         Event savedEvent3 = eventRepository.save(createEvent("저장", EventCategory.NETWORKING_MENTORING));
 
         List<EventResponse.HomeEventResponse> result = eventService.getSupplementaryEvents(
-                EventCategory.NETWORKING_MENTORING);
+                EventCategory.NETWORKING_MENTORING , null);
 
         assertThat(result).isNotEmpty();
         assertThat(result.get(0).getId()).isEqualTo(savedEvent3.getId());
@@ -656,7 +657,7 @@ public class EventServiceTest {
 
         eventActionRepository.save(action);
 
-        List<EventResponse.HomeEventResponse> events = eventService.getRecommendedEvents(3L);
+        List<EventResponse.HomeEventResponse> events = eventService.getRecommendedEvents(3L , null);
         assertThat(events).isNotEmpty();
         assertThat(events.size()).isEqualTo(2);
         for (EventResponse.HomeEventResponse event : events) {

--- a/src/test/java/com/example/skillup/domain/event/service/EventServiceTimeTest.java
+++ b/src/test/java/com/example/skillup/domain/event/service/EventServiceTimeTest.java
@@ -1,23 +1,33 @@
 package com.example.skillup.domain.event.service;
 
 
+import static com.example.skillup.domain.event.enums.ActionType.APPLY;
+
 import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventAction;
 import com.example.skillup.domain.event.entity.HashTag;
-import com.example.skillup.domain.event.enums.*;
-import com.example.skillup.domain.event.repository.*;
+import com.example.skillup.domain.event.enums.ActionType;
+import com.example.skillup.domain.event.enums.ActorType;
+import com.example.skillup.domain.event.enums.EventCategory;
+import com.example.skillup.domain.event.enums.EventSortType;
+import com.example.skillup.domain.event.enums.EventStatus;
+import com.example.skillup.domain.event.enums.HashTagCategory;
+import com.example.skillup.domain.event.repository.EventActionRepository;
+import com.example.skillup.domain.event.repository.EventRepository;
+import com.example.skillup.domain.event.repository.HashTagRepository;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.time.LocalDateTime;
-import java.util.*;
-
-import static com.example.skillup.domain.event.enums.ActionType.APPLY;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -112,11 +122,11 @@ public class EventServiceTimeTest
                 .build();
 
 
-        eventService.getRecommendedEvents(3L);
+        eventService.getRecommendedEvents(3L , null);
         eventService.getSupplementaryEvents(
-                EventCategory.NETWORKING_MENTORING);
-        eventService.getEventBySearch(condPopularity);
+                EventCategory.NETWORKING_MENTORING , null);
+        eventService.getEventBySearch(condPopularity , null);
         eventService.getEventDetail(3L,null,"3L");
-        eventService.getClosingSoonEvents(null,8);
+        eventService.getClosingSoonEvents(8 , null);
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

홈화면 행사 조회시 북마크 여부를 확인하는 기능이 누락된것을 확인했습니다.

이후 
- 추천 행사 리스트 조회
- 곧 종료되는 행사 리스트 조회
- 카테고리별 행사 조회
- 행사 검색 시
- 홈 화면에서 행사 개수가 부족할 시 등등
행사 관련 조회 api 에 북마크 기능 확인 여부를 추가했습니다.

```
    private Set<Long> getBookmarkedEventId(UsersDetails user, List<Long> eventIds) {
        Set<Long> bookmarkedEventIds = new HashSet<>();

        if (user != null && !eventIds.isEmpty()) {
            bookmarkedEventIds.addAll(eventBookmarkRepository.findBookmarkedEventIds(user.getUser().getId(), eventIds));
        }
        return bookmarkedEventIds;
    }
```
를 활용하여 중복되는 코드를 줄였습니다.

로직 변경관련하여 Test 부분의 인자값도 수정했습니다.

또한 최근 행사 조회시 User 에서 targetRole 에 바로 접근 시 에러가 발생해 해당 부분 수정했습니다.



## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
