### PR TITLE
[FIX] 마이 페이지 홈 API 프로필 이미지 전달 및 qna 권한 모두 허용으로 변경

### DIFF
--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -23,6 +23,7 @@ public class UserResponse {
     public static class MyPageHomeResponse {
         private String name;
         private String email;
+        private String profileImageUrl;
     }
 
     @Getter

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -65,6 +65,7 @@ public class UserMapper {
         return UserResponse.MyPageHomeResponse.builder()
                 .email(user.getEmail())
                 .name(user.getName())
+                .profileImageUrl(user.getProfileImageUrl())
                 .build();
     }
 

--- a/src/main/java/com/example/skillup/global/config/SecurityConstant.java
+++ b/src/main/java/com/example/skillup/global/config/SecurityConstant.java
@@ -33,6 +33,7 @@ public class SecurityConstant {
             "/user/test-login",                  // GET (테스트용)
             "/user/my-page/profile/interest",    // GET
             "/user/my-page/with-draw/category",   // GET
+            "/user/my-page/qna",   // GET
 
             // ========== OAuth (public) ==========
             "/oauth/**"


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

1. 마이 페이지 홈 API에서 프로필 이미지를 전달하는 부분을 추가하였습니다
2. 기획대로 QNA 보기 권한을 모두 허용으로 변경하였습니다.

## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
