### PR TITLE
[FEAT] 글로벌 핸들러에서 잡는 예외 범위 추가

### DIFF
--- a/src/main/java/com/example/skillup/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/example/skillup/global/exception/CommonErrorCode.java
@@ -22,6 +22,7 @@ public enum CommonErrorCode implements ResultCode {
     FILE_SIZE_EXCEED("FILE_SIZE_EXCEED", "파일 크기가 제한을 초과했습니다.", HttpStatus.BAD_REQUEST),
     FILE_DELETE_ERROR("FILE_DELETE_ERROR" , "파일 삭제중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),
     ELASTICSEARCH_ERROR("ELASTICSEARCH_ERROR" , "일라스틱 서치 업로드 중 오류가 발생했습니다." , HttpStatus.BAD_GATEWAY),
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버에 오류가 발생했습니다",HttpStatus.INTERNAL_SERVER_ERROR)
     ;
 
 

--- a/src/main/java/com/example/skillup/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/skillup/global/exception/GlobalExceptionHandler.java
@@ -2,12 +2,19 @@ package com.example.skillup.global.exception;
 
 import com.example.skillup.global.common.BaseResponse;
 import com.example.skillup.global.exception.response.ValidationErrors;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.List;
 
@@ -56,6 +63,57 @@ public class GlobalExceptionHandler
                 .body(response);
     }
 
+
+
+    @ExceptionHandler({
+            HttpMessageNotReadableException.class,      // JSON 깨짐
+            MethodArgumentTypeMismatchException.class,  // enum, 숫자 타입 오류
+            HttpMessageConversionException.class        // Jackson 변환 계열 최상위
+    })
+    public ResponseEntity<BaseResponse<Void>> handleRequestConvertException(Exception ex) {
+        log.warn("Request conversion error", ex);
+
+        return ResponseEntity
+                .badRequest()
+                .body(BaseResponse.error(CommonErrorCode.INVALID_INPUT_VALUE));
+    }
+
+    /* =========================
+     * 필수 RequestParam 누락
+     * ========================= */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMissingParameter(
+            MissingServletRequestParameterException ex
+    ) {
+        log.warn("Missing request parameter: {}", ex.getParameterName());
+
+        return ResponseEntity
+                .badRequest()
+                .body(BaseResponse.error(CommonErrorCode.INVALID_INPUT_VALUE));
+    }
+
+    /* =========================
+     * @RequestParam 제약조건 실패
+     * ========================= */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<BaseResponse<Void>> handleConstraintViolation(
+            ConstraintViolationException ex
+    ) {
+        log.warn("ConstraintViolationException", ex);
+
+        return ResponseEntity
+                .badRequest()
+                .body(BaseResponse.error(CommonErrorCode.INVALID_INPUT_VALUE));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponse<Void>> handleUnexpectedException(Exception ex) {
+        log.error("Unhandled exception", ex);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(BaseResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
     public record ErrorResponse(String code, String message, String exception) {}
 
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

글로벌 핸들러에서 잡지 않아 401을 반환하는 것을 고치기 위해서 핸들러가 다루는 예외 범위를 추가하였습니다
예를 들어 고치기 전에는
`{
  "category": "CONFERENCE_SEMINAR",
  "isOnline": sd,
  "isFree": true,
  "startDate": "2026-01-22T15:43:54.841Z",
  "endDate": "2026-01-22T15:43:54.841Z",
  "sort": "POPULARITY",
  "targetRole": "ALL",
  "page": 0,
  "validDateRange": true
}`
isOnline 값에 boolean이 와야하지만 stirng이 와도 401을 반환했지만 현재는  HttpMessageNotReadableException.class 예외를 핸들러에서 잡아 400을 반환합니다
그리고 기타 서버에서 잡지 않은 예외들은 500을 반환하도록 하였습니다

## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
