### PR TITLE
[FIX] : 쿼리문의 변수 이름과 메소드의 변수 이름이 달라 수정

### DIFF
--- a/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/skillup/domain/admin/controller/AdminController.java
@@ -1,6 +1,5 @@
 package com.example.skillup.domain.admin.controller;
 
-import co.elastic.clients.elasticsearch.xpack.usage.Base;
 import com.example.skillup.domain.admin.dto.AdminLoginRequest;
 import com.example.skillup.domain.admin.dto.AdminResponse;
 import com.example.skillup.domain.admin.dto.SynonymRequest;
@@ -14,9 +13,14 @@ import com.example.skillup.global.search.service.EventIndexerService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/admin")
@@ -79,9 +83,9 @@ public class AdminController {
 
     @GetMapping("/users")
     @Operation(summary = "검색 조건으로 유저를 조회합니다.")
-    public BaseResponse<AdminResponse.AdminUserPageResponse> getUsersBySearch(@RequestParam(required = false) String keyWard
+    public BaseResponse<AdminResponse.AdminUserPageResponse> getUsersBySearch(@RequestParam(required = false) String keyword
             , @RequestParam boolean deleted, @RequestParam int page) {
-        return BaseResponse.success("성공적으로 유저가 조회 되었습니다.", adminService.getUsersBySearch(keyWard,deleted,page));
+        return BaseResponse.success("성공적으로 유저가 조회 되었습니다.", adminService.getUsersBySearch(keyword,deleted,page));
     }
 
     @GetMapping("/users/{userId}")

--- a/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/skillup/domain/admin/service/AdminService.java
@@ -143,9 +143,9 @@ public class AdminService {
         return deletedTerms;
     }
 
-    public AdminResponse.AdminUserPageResponse getUsersBySearch(String keyWard, boolean deleted, int page) {
+    public AdminResponse.AdminUserPageResponse getUsersBySearch(String keyword, boolean deleted, int page) {
         Pageable pageable = PageRequest.of(page, 20);
-        List<Users> users = userRepository.findUsersByKeyWardAndDeleted(keyWard, deleted, pageable);
+        List<Users> users = userRepository.findUsersByKeyWardAndDeleted(keyword, deleted, pageable);
         List<UserResponse.AdminUserResponse> adminUserResponse = new ArrayList<>();
 
         for (Users user : users) {

--- a/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
@@ -30,7 +30,7 @@ public interface UserRepository extends JpaRepository<Users, Long> {
                     """,
             nativeQuery = true
     )
-    List<Users> findUsersByKeyWardAndDeleted(@Param("keyWard") String keyWard, @Param("deleted") Boolean deleted,
+    List<Users> findUsersByKeyWardAndDeleted(@Param("keyword") String keyword, @Param("deleted") Boolean deleted,
                                              Pageable pageable);
 
     @Query(value = """


### PR DESCRIPTION

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

>     @Query(
>             value = """
>                     SELECT *
>                     FROM users u
>                     WHERE
>                         (:deleted = true
>                          OR (:deleted = false AND u.deleted_at IS NULL))
>                       AND (:keyword IS NULL
>                            OR u.email LIKE CONCAT('%', :keyword, '%')
>                            OR u.name  LIKE CONCAT('%', :keyword, '%'))
>                     ORDER BY u.created_at DESC
>                     """,
>             nativeQuery = true
>     )
>     List<Users> findUsersByKeyWardAndDeleted(@Param("keyword") String keyword, @Param("deleted") Boolean deleted,
>                                              Pageable pageable);

해당 부분의 @Param("keyword") 와 keyword  가 이름이 달라서 에러가 발생하여 수정했습니다.

## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
