### PR TITLE
[FIX] : fallback 인기 추천 반환 + 검색 결과 북마크 반영

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -276,10 +276,11 @@ public class EventController {
     }
 
     @PostMapping("/search/home")
-    @Operation(summary = "행사 검색 api", description = "검색 내용의 행사들을 불러옵니다.")
+    @Operation(summary = "행사 검색 api", description = "검색 내용의 행사들을 불러옵니다.(fallback 의 값이 true 이면 검색 결과 0 추천 행사 , false 이면 검색 성공)")
     public BaseResponse<EventResponse.SearchEventResponseList> searchEvents(
-            @Valid @RequestBody EventRequest.EventSearchRequest request) {
-        return BaseResponse.success("검색 성공", eventSearchService.search(request));
+            @Valid @RequestBody EventRequest.EventSearchRequest request,
+            @AuthenticationPrincipal(errorOnInvalidType = false) UsersDetails user) {
+        return BaseResponse.success("검색 성공", eventSearchService.search(request , user));
     }
 
     @PatchMapping("/{eventId}/apply")

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -132,6 +132,7 @@ public class EventResponse {
         @Builder.Default
         private List<HomeEventResponse> homeEventResponseList = Collections.emptyList();
         private CommonResponse.PageInfoResponse pageInfoResponse;
+        private boolean fallback;
     }
 
     @Getter

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -126,7 +126,8 @@ public class EventMapper {
 
     public EventResponse.HomeEventResponse mapEsDocToHomeItem(
             EventDocument eventDocument,
-            Double score
+            Double score,
+            boolean isBookmarked
     ) {
         LocalDateTime startDt = eventDocument.getEventStart() == null
                 ? null
@@ -171,7 +172,7 @@ public class EventMapper {
                 .d_dayLabel(d_day)
                 .recommended(Boolean.TRUE.equals(eventDocument.getRecommendedManual()))
                 .ad(Boolean.TRUE.equals(eventDocument.getAd()))
-                .bookmarked(false)
+                .bookmarked(isBookmarked)
                 .category(category)
                 .recommendedRate(recommendedRate)
                 .build();

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -178,10 +178,11 @@ public class EventMapper {
     }
 
     public EventResponse.SearchEventResponseList toSearchEventResponseList
-            (int total, List<EventResponse.HomeEventResponse> events) {
+            (int total, List<EventResponse.HomeEventResponse> events , boolean fallback) {
         return EventResponse.SearchEventResponseList.builder()
                 .total(total)
                 .homeEventResponseList(events)
+                .fallback(fallback)
                 .build();
     }
 

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -480,7 +480,7 @@ public class EventService {
                 (condition, pageable, since, now);
     }
 
-    private Set<Long> getBookmarkedEventId(UsersDetails user, List<Long> eventIds) {
+    public Set<Long> getBookmarkedEventId(UsersDetails user, List<Long> eventIds) {
         Set<Long> bookmarkedEventIds = new HashSet<>();
 
         if (user != null && !eventIds.isEmpty()) {

--- a/src/main/java/com/example/skillup/global/search/exception/SearchErrorCode.java
+++ b/src/main/java/com/example/skillup/global/search/exception/SearchErrorCode.java
@@ -12,6 +12,7 @@ public enum SearchErrorCode implements ResultCode {
     SEARCH_SEARCH_QUERY_TOO_SHORT("SEARCH_SEARCH_QUERY_TOO_SHORT", "검색어는 2글자 이상 입력해 주세요.", HttpStatus.BAD_REQUEST),
     SEARCH_SEARCH_ERROR("SEARCH_SEARCH_ERROR", "검색 기능 시 에러가 발생했습니다.", HttpStatus.BAD_REQUEST),
     GROUP_ENTITY_NOT_FOUND("GROUP_ENTITY_NOT_FOUND","GRUOP 이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    SEARCH_DOCUMENT_SOURCE_NULL("SEARCH_DOCUMENT_SOURCE_NULL", "검색 결과 문서 데이터(_source)가 비어있습니다.", HttpStatus.SERVICE_UNAVAILABLE),
     ;
 
     private final String code;

--- a/src/main/java/com/example/skillup/global/search/service/EventSearchService.java
+++ b/src/main/java/com/example/skillup/global/search/service/EventSearchService.java
@@ -17,6 +17,7 @@ import com.example.skillup.domain.event.exception.EventErrorCode;
 import com.example.skillup.domain.event.exception.EventException;
 import com.example.skillup.domain.event.mapper.EventMapper;
 import com.example.skillup.domain.event.repository.EventRepository;
+import com.example.skillup.domain.event.service.EventService;
 import com.example.skillup.domain.user.entity.UsersDetails;
 import com.example.skillup.global.search.document.EventDocument;
 import com.example.skillup.global.search.exception.SearchErrorCode;
@@ -26,6 +27,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,10 +46,11 @@ public class EventSearchService {
     private final ElasticsearchClient elasticsearchClient;
     private final EventMapper eventMapper;
     private final EventRepository eventRepository;
+    private final EventService eventService;
 
     LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
 
-    public EventResponse.SearchEventResponseList search(EventRequest.EventSearchRequest request , UsersDetails user) {
+    public EventResponse.SearchEventResponseList search(EventRequest.EventSearchRequest request, UsersDetails user) {
 
         // 1) 전처리
         String searchString = request.getSearchString() == null ? "" : request.getSearchString().trim();
@@ -153,19 +157,37 @@ public class EventSearchService {
                     PageRequest.of(0, 4)
             );
 
+            List<Long> eventIds = rows.stream().map(r -> r.getEvent().getId()).toList();
+            Set<Long> bookmarkedEventIds = eventService.getBookmarkedEventId(user, eventIds);
+
             return eventMapper.toSearchEventResponseList(0, rows.stream()
                     .map(r -> {
                         double score = r.getPopularity();
                         Event event = r.getEvent();
                         boolean recommended = event.isRecommendedManual();
-                        return eventMapper.toFeaturedEvent(event, false, recommended, event.isAd(), score);
-                    }).toList() , true);
+                        boolean bookmarked = (user != null) && bookmarkedEventIds.contains(event.getId());
+                        return eventMapper.toFeaturedEvent(event, bookmarked, recommended, event.isAd(), score);
+                    }).toList(), true);
         }
+
+        List<Long> eventIdsForSearching = documentSearchResponse.hits().hits().stream()
+                .map(hit -> hit.source() == null ? null : hit.source().getId())
+                .filter(Objects::nonNull)
+                .toList();
+        Set<Long> bookmarkedEventIdsForSearching = eventService.getBookmarkedEventId(user, eventIdsForSearching);
+
         List<EventResponse.HomeEventResponse> items = documentSearchResponse.hits().hits().stream()
-                .map(hit -> eventMapper.mapEsDocToHomeItem(hit.source(), hit.score()))
+                .map(hit -> {
+                    EventDocument document = hit.source();
+                    if (document == null) {
+                        throw new SearchException(SearchErrorCode.SEARCH_DOCUMENT_SOURCE_NULL);
+                    }
+                    boolean bookmarked = (user != null) && bookmarkedEventIdsForSearching.contains(document.getId());
+                    return eventMapper.mapEsDocToHomeItem(document, hit.score(), bookmarked);
+                })
                 .toList();
 
-        return eventMapper.toSearchEventResponseList(total, items , false);
+        return eventMapper.toSearchEventResponseList(total, items, false);
     }
 }
 

--- a/src/main/java/com/example/skillup/global/search/service/EventSearchService.java
+++ b/src/main/java/com/example/skillup/global/search/service/EventSearchService.java
@@ -17,6 +17,7 @@ import com.example.skillup.domain.event.exception.EventErrorCode;
 import com.example.skillup.domain.event.exception.EventException;
 import com.example.skillup.domain.event.mapper.EventMapper;
 import com.example.skillup.domain.event.repository.EventRepository;
+import com.example.skillup.domain.user.entity.UsersDetails;
 import com.example.skillup.global.search.document.EventDocument;
 import com.example.skillup.global.search.exception.SearchErrorCode;
 import com.example.skillup.global.search.exception.SearchException;
@@ -45,7 +46,7 @@ public class EventSearchService {
 
     LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
 
-    public EventResponse.SearchEventResponseList search(EventRequest.EventSearchRequest request) {
+    public EventResponse.SearchEventResponseList search(EventRequest.EventSearchRequest request , UsersDetails user) {
 
         // 1) 전처리
         String searchString = request.getSearchString() == null ? "" : request.getSearchString().trim();
@@ -149,22 +150,22 @@ public class EventSearchService {
                     null,
                     since,
                     LocalDateTime.now(),
-                    PageRequest.of(0, 10)
+                    PageRequest.of(0, 4)
             );
 
-            return eventMapper.toSearchEventResponseList(rows.size(), rows.stream()
+            return eventMapper.toSearchEventResponseList(0, rows.stream()
                     .map(r -> {
                         double score = r.getPopularity();
                         Event event = r.getEvent();
                         boolean recommended = event.isRecommendedManual();
                         return eventMapper.toFeaturedEvent(event, false, recommended, event.isAd(), score);
-                    }).toList());
+                    }).toList() , true);
         }
         List<EventResponse.HomeEventResponse> items = documentSearchResponse.hits().hits().stream()
                 .map(hit -> eventMapper.mapEsDocToHomeItem(hit.source(), hit.score()))
                 .toList();
 
-        return eventMapper.toSearchEventResponseList(total, items);
+        return eventMapper.toSearchEventResponseList(total, items , false);
     }
 }
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

- 이벤트 검색 API에서 검색 결과가 0건일 때 FE에서는 “검색 결과 없음”과 “대체 추천(인기순)”을 함께 보여줘야 함.
- 기존에는 검색 결과가 0이면 단순히 빈 결과로만 내려가거나, 추천 리스트가 내려가더라도 “fallback 추천”임이 명확히 전달되지 않아 UI에서 구분이 어려웠음.
- 또한 검색 결과가 있을 때도 북마크 여부(bookmarked)가 응답에 반영되지 않았던 코드 발견


## ✨ 변경 사항
### 1) 검색 결과 0건 fallback 처리 개선
- 검색 결과가 0이면 인기순 이벤트를 조회하여 추천 리스트로 반환
- 응답에 `fallback=true`로 명시하여 “검색 결과 0이지만 추천을 내려주는 응답”임을 FE가 구분 가능하도록 처리

### 2) 검색 결과(ES hit)에서도 북마크 여부 반영
- 현재 페이지의 검색 결과 이벤트 ID만 추출 → 북마크를 배치 조회(IN query) → 응답 매핑 시 `bookmarked` 필드 반영

### 3) ES hit source가 null인 케이스 예외 코드 추가
- 검색 결과에서 `source`가 비어있는 경우를 식별하기 위해 에러 코드 추가
- `SearchErrorCode.SEARCH_DOCUMENT_SOURCE_NULL` (503)


## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
