### PR TITLE
[FEAT] : 관리자 이벤트 리스트 조회 api 추가

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -6,6 +6,7 @@ import com.example.skillup.domain.event.dto.response.EventResponse.EventApplyRes
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventBookmark;
 import com.example.skillup.domain.event.enums.EventCategory;
+import com.example.skillup.domain.event.enums.EventSortType;
 import com.example.skillup.domain.event.enums.EventStatus;
 import com.example.skillup.domain.event.service.EventBannerService;
 import com.example.skillup.domain.event.service.EventBookmarkService;
@@ -134,6 +135,20 @@ public class EventController {
     ) {
         return BaseResponse.success("행사관리 페이지 조회 성공", eventService.getAdminEventPage(request));
     }
+
+
+    @GetMapping("/admin/drafts")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "임시저장(DRAFT) 행사 목록 조회(관리자용)",
+            description = "관리자 모달에서 선택할 임시저장(DRAFT) 행사 목록을 정렬 기준에 따라 조회합니다 최대 200개까지. "
+                    + "정렬 방식은 DEADLINE(모집 마감일순) ,CREATED_AT(등록일 순) ")
+    public BaseResponse<EventResponse.AdminDraftEventResponse> getAdminDraftEvents(
+            @RequestParam(required = false, defaultValue = "CREATED_AT") EventSortType sort
+    ) {
+        return BaseResponse.success("임시저장 행사 목록 조회 성공",
+                eventService.getAdminDraftEvents(sort));
+    }
+
 
     @GetMapping("/{eventId}")
     @Operation(summary = "행사 상세 조회 API", description = "특정 행사의 상세 정보를 불러옵니다.")

--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -30,6 +30,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -108,6 +109,30 @@ public class EventController {
             @PathVariable Long eventId
     ) {
         return BaseResponse.success("행사가 삭제되었습니다.", eventService.deleteEvent(eventId));
+    }
+
+    @GetMapping("/admin")
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(
+            summary = "행사관리 페이지 조회 API(관리자용)",
+            description = """
+                행사관리 페이지에 필요한 데이터를 조회합니다.
+                - 종료된 행사 포함 토글(includeEnded)
+                - 카테고리 탭 필터(category)
+                - 검색(keyword)
+                - 정렬(EVENT_START("행사 시작일 순"),VIEWS("조회수 많은 순"),BOOKMARKS("저장 많은 순"),CREATED_AT("등록일 순"))
+                - 페이지
+                """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "행사관리 페이지 조회 성공",
+            content = @Content(mediaType = "application/json")
+    )
+    public BaseResponse<EventResponse.AdminEventPageResponse> getEventAdminPage(
+            @Valid @ModelAttribute EventRequest.AdminEventPageRequest request
+    ) {
+        return BaseResponse.success("행사관리 페이지 조회 성공", eventService.getAdminEventPage(request));
     }
 
     @GetMapping("/{eventId}")

--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -117,13 +117,13 @@ public class EventController {
     @Operation(
             summary = "행사관리 페이지 조회 API(관리자용)",
             description = """
-                행사관리 페이지에 필요한 데이터를 조회합니다.
-                - 종료된 행사 포함 토글(includeEnded)
-                - 카테고리 탭 필터(category)
-                - 검색(keyword)
-                - 정렬(EVENT_START("행사 시작일 순"),VIEWS("조회수 많은 순"),BOOKMARKS("저장 많은 순"),CREATED_AT("등록일 순"))
-                - 페이지
-                """
+                    행사관리 페이지에 필요한 데이터를 조회합니다.
+                    - 종료된 행사 포함 토글(includeEnded)
+                    - 카테고리 탭 필터(category)
+                    - 검색(keyword)
+                    - 정렬(EVENT_START("행사 시작일 순"),VIEWS("조회수 많은 순"),BOOKMARKS("저장 많은 순"),CREATED_AT("등록일 순"))
+                    - 페이지
+                    """
     )
     @ApiResponse(
             responseCode = "200",

--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -39,11 +39,13 @@ public class EventRequest {
 
         @NotNull(message = "행사 시작일을 입력해주세요.")
         private LocalDateTime eventStart;
+        @NotNull(message = "행사 마감일을 입력해주세요.")
         private LocalDateTime eventEnd;
 
 
         @NotNull(message = "모집 시작일을 입력해주세요.")
         private LocalDateTime recruitStart;
+        @NotNull(message = "모집 마감일을 입력해주세요.")
         private LocalDateTime recruitEnd;
 
 

--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -257,4 +257,26 @@ public class EventRequest {
         @NotEmpty List<Long> bannerIds;
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class AdminEventPageRequest {
+
+        @Builder.Default
+        private Boolean includeEnded = false;
+
+        @NotNull(message = "카테고리를 선택해주세요.")
+        @Builder.Default
+        private EventCategory category = EventCategory.ALL;
+
+        private String keyword;
+
+        @Builder.Default
+        private EventSortType sort = EventSortType.EVENT_START;
+
+        @NotNull(message = "페이지 번호를 입력해주세요.")
+        private Integer page;
+
+    }
+
 }

--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -255,8 +255,9 @@ public class EventRequest {
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class BannerOrderUpdateRequest{
-        @NotEmpty List<Long> bannerIds;
+    public static class BannerOrderUpdateRequest {
+        @NotEmpty
+        List<Long> bannerIds;
     }
 
     @Getter

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -164,7 +164,7 @@ public class EventResponse {
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class EventBannerAdminResponse{
+    public static class EventBannerAdminResponse {
         private List<EventBannerResponse> eventActiveBannerList;
         private List<EventBannerResponse> eventPastBannerList;
     }
@@ -239,7 +239,7 @@ public class EventResponse {
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class AdminDraftEventResponse{
+    public static class AdminDraftEventResponse {
         List<AdminEventRow> draftEventRowList;
         Long totalEventCount;
     }

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -178,4 +178,59 @@ public class EventResponse {
         private String comment;
 
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class AdminEventPageResponse {
+        //통계
+        private AdminEventSummary summary;
+        // 카테고리 카운트
+        private List<AdminCategoryCount> categoryCounts;
+
+        private List<AdminEventRow> events;
+        private CommonResponse.PageInfoResponse pageInfoResponse;
+    }
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class AdminEventSummary {
+        private long totalRegisteredCount;
+        private long recruitingScheduledCount;  // 모집예정
+        private long recruitingCount;           // 모집중
+        private long recruitingClosedCount;     // 모집마감
+        private long ongoingCount;
+        private Long creatableCount;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class AdminCategoryCount {
+        private String category;
+        private long count;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class AdminEventRow {
+        private Long id;
+
+        private Long no;
+
+        private String title;
+        private String category;
+
+        private String eventPeriodText;
+
+        private long viewsCount;
+        private long bookmarksCount;
+
+        private String status;
+
+        private LocalDateTime createdAt;
+    }
 }

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -216,6 +216,7 @@ public class EventResponse {
     @Getter
     @Builder
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class AdminEventRow {
         private Long id;
 
@@ -225,12 +226,21 @@ public class EventResponse {
         private String category;
 
         private String eventPeriodText;
+        private LocalDate eventRecruitEnd;
 
-        private long viewsCount;
-        private long bookmarksCount;
+        private Long viewsCount;
+        private Long bookmarksCount;
 
         private String status;
 
         private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class AdminDraftEventResponse{
+        List<AdminEventRow> draftEventRowList;
+        Long totalEventCount;
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/enums/AdminEventListStatus.java
+++ b/src/main/java/com/example/skillup/domain/event/enums/AdminEventListStatus.java
@@ -1,0 +1,15 @@
+package com.example.skillup.domain.event.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminEventListStatus {
+    RECRUIT_SCHEDULED("모집예정"),
+    RECRUITING("모집중"),
+    RECRUIT_CLOSED("모집마감"),
+    ENDED("종료");
+
+    private final String toKorean;
+}

--- a/src/main/java/com/example/skillup/domain/event/enums/EventCategory.java
+++ b/src/main/java/com/example/skillup/domain/event/enums/EventCategory.java
@@ -9,7 +9,8 @@ public enum EventCategory {
     CONFERENCE_SEMINAR("컨퍼런스/세미나"),
     COMPETITION_HACKATHON("공모전/해커톤"),
     BOOTCAMP_CLUB("부트캠프/동아리"),
-    NETWORKING_MENTORING("네트워킹/멘토링");
+    NETWORKING_MENTORING("네트워킹/멘토링"),
+    ALL("전체"),;
 
     private final String toKorean;
 }

--- a/src/main/java/com/example/skillup/domain/event/enums/EventSortType.java
+++ b/src/main/java/com/example/skillup/domain/event/enums/EventSortType.java
@@ -8,7 +8,12 @@ import lombok.RequiredArgsConstructor;
 public enum EventSortType {
     POPULARITY("추천순"),
     LATEST("최신순"),
-    DEADLINE("모집 마감일순");
+    DEADLINE("모집 마감일순"),
+
+    EVENT_START("행사 시작일 순"),
+    VIEWS("조회수 많은 순"),
+    BOOKMARKS("저장 많은 순"),
+    CREATED_AT("등록일 순");
 
     private final String toKorean;
 }

--- a/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
@@ -19,7 +19,7 @@ public enum EventErrorCode implements ResultCode {
     BANNER_ENTITY_NOT_FOUND("BANNER_ENTITY_NOT_FOUND", "배너가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     INVALID_BANNER_ID("INVALID_BANNER_ID" , "잘못된 배너 아이디입니다." , HttpStatus.BAD_REQUEST),
     INVALID_LOCATION_TEXT("INVALID_LOCATION_TEXT","오프라인 행사에는 주소가 필수입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_EVENT_SORT_TYPE("INVALID_EVENT_SORT_TYPE", "관리자 페이지에서 지원하지 않는 정렬 방식입니다.", HttpStatus.BAD_REQUEST),;
+    INVALID_EVENT_SORT_TYPE("INVALID_EVENT_SORT_TYPE", "해당 페이지에서 지원하지 않는 정렬 방식입니다.", HttpStatus.BAD_REQUEST),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
+++ b/src/main/java/com/example/skillup/domain/event/exception/EventErrorCode.java
@@ -18,7 +18,8 @@ public enum EventErrorCode implements ResultCode {
     EVENT_SEARCH_ERROR("EVENT_SEARCH_ERROR", "검색 기능 시 에러가 발생했습니다.", HttpStatus.BAD_REQUEST),
     BANNER_ENTITY_NOT_FOUND("BANNER_ENTITY_NOT_FOUND", "배너가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     INVALID_BANNER_ID("INVALID_BANNER_ID" , "잘못된 배너 아이디입니다." , HttpStatus.BAD_REQUEST),
-    INVALID_LOCATION_TEXT("INVALID_LOCATION_TEXT","오프라인 행사에는 주소가 필수입니다.", HttpStatus.BAD_REQUEST),;
+    INVALID_LOCATION_TEXT("INVALID_LOCATION_TEXT","오프라인 행사에는 주소가 필수입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_EVENT_SORT_TYPE("INVALID_EVENT_SORT_TYPE", "관리자 페이지에서 지원하지 않는 정렬 방식입니다.", HttpStatus.BAD_REQUEST),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -4,24 +4,31 @@ import static com.example.skillup.global.common.CommonMapper.toBigDecimal;
 
 import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.dto.response.EventResponse;
+import com.example.skillup.domain.event.dto.response.EventResponse.AdminCategoryCount;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.HashTag;
 import com.example.skillup.domain.event.entity.TargetRole;
+import com.example.skillup.domain.event.enums.AdminEventListStatus;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventStatus;
+import com.example.skillup.domain.event.repository.EventRepository.AdminCategoryCountProjection;
+import com.example.skillup.domain.event.repository.EventRepository.AdminEventSummaryProjection;
 import com.example.skillup.domain.event.repository.EventRepositoryImpl;
 import com.example.skillup.domain.map.provider.GeocodingProvider.GeoPoint;
 import com.example.skillup.global.common.CommonMapper;
+import com.example.skillup.global.common.CommonResponse.PageInfoResponse;
 import com.example.skillup.global.search.document.EventDocument;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
@@ -31,7 +38,7 @@ public class EventMapper {
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
-    public Event toEntity(EventRequest.CreateEvent request , String thumbnailUrl , GeoPoint geoPoint) {
+    public Event toEntity(EventRequest.CreateEvent request, String thumbnailUrl, GeoPoint geoPoint) {
 
         BigDecimal lat = (geoPoint == null) ? null : toBigDecimal(geoPoint.lat());
         BigDecimal lng = (geoPoint == null) ? null : toBigDecimal(geoPoint.lng());
@@ -58,7 +65,7 @@ public class EventMapper {
                 .build();
     }
 
-    public EventResponse.EventSelectResponse toEventDetailInfo(Event event , boolean isBookmarked) {
+    public EventResponse.EventSelectResponse toEventDetailInfo(Event event, boolean isBookmarked) {
         return EventResponse.EventSelectResponse.builder()
                 .id(event.getId())
                 .title(event.getTitle())
@@ -91,7 +98,8 @@ public class EventMapper {
                 .build();
     }
 
-    public EventResponse.HomeEventResponse toFeaturedEvent(Event event, boolean bookmarked, boolean recommended, boolean ad , Double score) {
+    public EventResponse.HomeEventResponse toFeaturedEvent(Event event, boolean bookmarked, boolean recommended,
+                                                           boolean ad, Double score) {
         DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy.MM.dd");
         String schedule = formatRange(event.getEventStart(), event.getEventEnd(), fmt);
         String priceText = event.getIsFree() != null && event.getIsFree()
@@ -190,7 +198,7 @@ public class EventMapper {
     }
 
     public EventResponse.SearchEventResponseList toSearchEventResponseList
-            (int total, List<EventResponse.HomeEventResponse> events , boolean fallback) {
+            (int total, List<EventResponse.HomeEventResponse> events, boolean fallback) {
         return EventResponse.SearchEventResponseList.builder()
                 .total(total)
                 .homeEventResponseList(events)
@@ -229,7 +237,8 @@ public class EventMapper {
                 .build();
     }
 
-    public List<EventResponse.HomeEventResponse> toHomeEventResponsList(List<Event> events , Set<Long> bookmarkedEventIds) {
+    public List<EventResponse.HomeEventResponse> toHomeEventResponsList(List<Event> events,
+                                                                        Set<Long> bookmarkedEventIds) {
         return events.stream()
                 .map(event -> {
                             boolean bookmarked = bookmarkedEventIds.contains(event.getId());
@@ -264,8 +273,83 @@ public class EventMapper {
                 .toList();
     }
 
-    public EventResponse.EventApplyResponse toEventApplyResponse(Long eventId)
-    {
+    public List<EventResponse.AdminEventRow> toAdminEventRowList(List<Event> events, int page, int size,
+                                                                 long totalCount, LocalDateTime now) {
+
+        int startIndex = page * size;
+
+        return IntStream.range(0, events.size()).mapToObj(
+                idx -> {
+                    Event event = events.get(idx);
+                    long no = totalCount - (startIndex + idx);
+
+                    AdminEventListStatus status = resolveAdminListStatus(event, now);
+
+                    return EventResponse.AdminEventRow.builder()
+                            .id(event.getId())
+                            .no(no)
+                            .title(event.getTitle())
+                            .category(event.getCategory().getToKorean())
+                            .eventPeriodText(formatRange(event.getEventStart(), event.getEventEnd(), DATE_FMT))
+                            .viewsCount(event.getViewsCount())
+                            .bookmarksCount(event.getBookmarkedCount())
+                            .status(status.getToKorean())
+                            .createdAt(event.getCreatedAt())
+                            .build();
+                }
+        ).toList();
+    }
+
+    public EventResponse.AdminEventPageResponse toAdminEventPageResponse(List<EventResponse.AdminEventRow> eventRowList,
+                                                                         AdminEventSummaryProjection countSummary,
+                                                                         List<AdminCategoryCountProjection> categoryCount,
+                                                                         PageInfoResponse pageInfoResponse) {
+
+        EventResponse.AdminEventSummary adminEventSummary = resolveAdminListStatus(countSummary);
+        List<EventResponse.AdminCategoryCount> adminCategoryCountList = resolveAdminCategory(categoryCount);
+
+        return EventResponse.AdminEventPageResponse.builder()
+                .events(eventRowList)
+                .summary(adminEventSummary)
+                .categoryCounts(adminCategoryCountList)
+                .pageInfoResponse(pageInfoResponse)
+                .build();
+    }
+
+    private List<AdminCategoryCount> resolveAdminCategory(List<AdminCategoryCountProjection> categoryCount){
+        List<AdminCategoryCount> adminCategoryCountList = new ArrayList<>();
+
+        long totalCount = 0;
+
+        for (AdminCategoryCountProjection countProjection : categoryCount) {
+
+            adminCategoryCountList.add(
+                    AdminCategoryCount.builder().category(countProjection.getCategory().getToKorean())
+                            .count(countProjection.getCount()).build());
+
+            totalCount += countProjection.getCount();
+        }
+
+        adminCategoryCountList.add(AdminCategoryCount.builder()
+                .category(EventCategory.ALL.getToKorean())
+                .count(totalCount)
+                .build());
+
+        return adminCategoryCountList;
+    }
+
+    private EventResponse.AdminEventSummary resolveAdminListStatus(AdminEventSummaryProjection countSummary) {
+        return EventResponse.AdminEventSummary.builder()
+                .totalRegisteredCount(countSummary.getTotalRegistered())
+                .recruitingScheduledCount(countSummary.getRecruitingScheduled())
+                .recruitingCount(countSummary.getRecruiting())
+                .recruitingClosedCount(countSummary.getRecruitingClosed())
+                .ongoingCount(countSummary.getOngoing())
+                .creatableCount(countSummary.getCreatableCount())
+                .build();
+    }
+
+    public EventResponse.EventApplyResponse toEventApplyResponse(Long eventId) {
         return EventResponse.EventApplyResponse.builder()
                 .eventId(eventId)
                 .comment("성공적으로 신청되었습니다.")
@@ -273,7 +357,27 @@ public class EventMapper {
     }
 
 
+    private AdminEventListStatus resolveAdminListStatus(Event e, LocalDateTime now) {
+        LocalDateTime recruitStart = e.getRecruitStart();
+        LocalDateTime recruitEnd = e.getRecruitEnd();
+        LocalDateTime eventEnd = e.getEventEnd();
 
+        if (eventEnd.isBefore(now)) {
+            return AdminEventListStatus.ENDED;
+        }
+        if (now.isBefore(recruitStart)) {
+            return AdminEventListStatus.RECRUIT_SCHEDULED;
+        }
+
+        if (!now.isBefore(recruitStart) && !now.isAfter(recruitEnd)) {
+            return AdminEventListStatus.RECRUITING;
+        }
+        if (now.isAfter(recruitEnd)) {
+            return AdminEventListStatus.RECRUIT_CLOSED;
+        }
+
+        return AdminEventListStatus.RECRUITING; //예외 상황
+    }
 
 
     private String formatRange(LocalDateTime start, LocalDateTime end, DateTimeFormatter fmt) {

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -300,6 +300,29 @@ public class EventMapper {
         ).toList();
     }
 
+
+
+    public EventResponse.AdminDraftEventResponse toAdminDraftEventRowList(List<Event> events){
+
+        List<EventResponse.AdminEventRow> eventRow = IntStream.range(0,events.size()).mapToObj(
+                idx -> {
+                    Event event = events.get(idx);
+                    long no = events.size() - idx;
+
+                    return EventResponse.AdminEventRow.builder()
+                            .id(event.getId())
+                            .no(no)
+                            .title(event.getTitle())
+                            .eventRecruitEnd(event.getRecruitEnd().toLocalDate())
+                            .eventPeriodText(formatRange(event.getEventStart(), event.getEventEnd(), DATE_FMT))
+                            .createdAt(event.getCreatedAt())
+                            .build();
+                }
+        ).toList();
+
+        return new EventResponse.AdminDraftEventResponse(eventRow , (long)events.size());
+    }
+
     public EventResponse.AdminEventPageResponse toAdminEventPageResponse(List<EventResponse.AdminEventRow> eventRowList,
                                                                          AdminEventSummaryProjection countSummary,
                                                                          List<AdminCategoryCountProjection> categoryCount,

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
@@ -2,6 +2,7 @@ package com.example.skillup.domain.event.repository;
 
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.enums.EventCategory;
+import com.example.skillup.domain.event.enums.EventStatus;
 import com.example.skillup.domain.event.exception.EventErrorCode;
 import com.example.skillup.domain.event.exception.EventException;
 import java.time.LocalDate;
@@ -299,6 +300,10 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
             @Param("includeEnded") boolean includeEnded,
             @Param("now") LocalDateTime now
     );
+
+    List<Event> findTop200ByStatusOrderByRecruitEndAsc(EventStatus eventStatus);
+
+    List<Event> findTop200ByStatusOrderByCreatedAtDesc(EventStatus eventStatus);
 
 
     public interface AdminEventSummaryProjection {

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
@@ -245,6 +245,94 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
                                                                                            @Param("due") LocalDateTime due,
                                                                                            Pageable pageable);
 
+    @Query("""
+        select e
+        from Event e
+        where (:category = com.example.skillup.domain.event.enums.EventCategory.ALL or e.category = :category)
+          and (:keyword is null or lower(e.title) like lower(concat('%', :keyword, '%')))
+          and (:includeEnded = true or e.eventEnd >= :now)
+          and (e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED)
+    """)
+    Page<Event> findAdminEvents(
+            @Param("includeEnded") boolean includeEnded,
+            @Param("category") EventCategory category,
+            @Param("keyword") String keyword,
+            @Param("now") LocalDateTime now,
+            Pageable pageable
+    );
+
+
+    @Query("""
+    select
+      coalesce(sum(case
+        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+        then 1 else 0 end), 0) as totalRegistered,
+
+      coalesce(sum(case
+        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+             and e.recruitStart > :now
+        then 1 else 0 end), 0) as recruitingScheduled,
+
+      coalesce(sum(case
+        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+             and e.recruitStart <= :now and :now <= e.recruitEnd
+        then 1 else 0 end), 0) as recruiting,
+
+      coalesce(sum(case
+        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+             and e.recruitEnd < :now and e.eventEnd >= :now
+        then 1 else 0 end), 0) as recruitingClosed,
+
+      coalesce(sum(case
+        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+             and e.eventStart <= :now and e.eventEnd >= :now
+        then 1 else 0 end), 0) as ongoing,
+        
+      coalesce(sum(case
+        when e.status = com.example.skillup.domain.event.enums.EventStatus.DRAFT
+        then 1 else 0 end), 0) as creatableCount
+
+    from Event e
+    where (:includeEnded = true or e.eventEnd >= :now) 
+""")
+    AdminEventSummaryProjection fetchAdminSummary(
+            @Param("includeEnded") boolean includeEnded,
+            @Param("now") LocalDateTime now
+    );
+
+
+    public interface AdminEventSummaryProjection {
+        long getTotalRegistered();
+        long getRecruitingScheduled();
+        long getRecruiting();
+        long getRecruitingClosed();
+        long getOngoing();
+        long getCreatableCount();
+    }
+
+    @Query("""
+    select e.category as category, count(e) as count
+    from Event e
+    where (:includeEnded = true or e.eventEnd is null or e.eventEnd >= :now)
+      and (:keyword is null or lower(e.title) like lower(concat('%', :keyword, '%')))
+      and (e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED)
+    group by e.category
+""")
+    List<AdminCategoryCountProjection> fetchAdminCategoryCounts(
+            @Param("includeEnded") boolean includeEnded,
+            @Param("keyword") String keyword,
+            @Param("now") LocalDateTime now
+    );
+
+    public interface AdminCategoryCountProjection {
+        EventCategory getCategory();
+        long getCount();
+    }
+
+
+
+
+
     public interface PopularEventProjection {
         Event getEvent();
         Long getViews14();

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
@@ -18,7 +18,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface EventRepository extends JpaRepository<Event, Long>, EventRepositoryNative {
     default Event getEvent(Long eventId) {
-        return findById(eventId).orElseThrow(() -> new EventException(EventErrorCode.EVENT_ENTITY_NOT_FOUND,  "EventID 가 " + eventId + "인"));
+        return findById(eventId).orElseThrow(
+                () -> new EventException(EventErrorCode.EVENT_ENTITY_NOT_FOUND, "EventID 가 " + eventId + "인"));
     }
 
     Page<Event> findAllByCategoryIn(Set<EventCategory> categories, Pageable pageable);
@@ -34,59 +35,58 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
-        UPDATE event
-           SET likes_count = GREATEST(likes_count + :delta, 0) ,  updated_at = CURRENT_TIMESTAMP
-         WHERE id = :eventId
-        """, nativeQuery = true)
+            UPDATE event
+               SET likes_count = GREATEST(likes_count + :delta, 0) ,  updated_at = CURRENT_TIMESTAMP
+             WHERE id = :eventId
+            """, nativeQuery = true)
     int incrementLikes(@Param("eventId") Long eventId, @Param("delta") int delta);
 
     @Query("""
-    select
-        e as event,
-        coalesce(sum(v.cnt), 0) as views14,
-        count(distinct eb.id) as bookmarksCnt,
-        (
-            coalesce(sum(v.cnt), 0) * 0.6
-          + count(distinct eb.id) * 0.3
-          + (
-                case when coalesce(sum(v.cnt), 0) > 0
-                     then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
-                     else 0
-                end
-            ) * 0.1
-        ) as popularity
-    from Event e
-    left join EventViewDaily v
-           on v.event = e and v.createdAt >= :since
-    left join EventBookmark eb
-           on eb.event = e and eb.createdAt >= :since
-    left join EventAction ea
-           on ea.event = e and ea.createdAt >= :since and ea.actionType = 'APPLY'
-    where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-      and (e.eventEnd is null or e.eventEnd >= :now)
-      and (
-            :roleName is null
-            or exists (
-                select 1
-                from Event e2 join e2.targetRoles tr2
-                where e2 = e and tr2.name = :roleName
-            )
-      )
-    group by e
-    order by
-        (
-            coalesce(sum(v.cnt), 0) * 0.6
-          + count(distinct eb.id) * 0.3
-          + (
-                case when coalesce(sum(v.cnt), 0) > 0
-                     then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
-                     else 0
-                end
-            ) * 0.1
-        ) desc,
-        e.createdAt desc
-    """)
-
+            select
+                e as event,
+                coalesce(sum(v.cnt), 0) as views14,
+                count(distinct eb.id) as bookmarksCnt,
+                (
+                    coalesce(sum(v.cnt), 0) * 0.6
+                  + count(distinct eb.id) * 0.3
+                  + (
+                        case when coalesce(sum(v.cnt), 0) > 0
+                             then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
+                             else 0
+                        end
+                    ) * 0.1
+                ) as popularity
+            from Event e
+            left join EventViewDaily v
+                   on v.event = e and v.createdAt >= :since
+            left join EventBookmark eb
+                   on eb.event = e and eb.createdAt >= :since
+            left join EventAction ea
+                   on ea.event = e and ea.createdAt >= :since and ea.actionType = 'APPLY'
+            where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+              and (e.eventEnd is null or e.eventEnd >= :now)
+              and (
+                    :roleName is null
+                    or exists (
+                        select 1
+                        from Event e2 join e2.targetRoles tr2
+                        where e2 = e and tr2.name = :roleName
+                    )
+              )
+            group by e
+            order by
+                (
+                    coalesce(sum(v.cnt), 0) * 0.6
+                  + count(distinct eb.id) * 0.3
+                  + (
+                        case when coalesce(sum(v.cnt), 0) > 0
+                             then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
+                             else 0
+                        end
+                    ) * 0.1
+                ) desc,
+                e.createdAt desc
+            """)
     List<PopularEventProjection> findPopularForHomeWithPopularity(@Param("roleName") String roleName,
                                                                   @Param("since") LocalDateTime since,
                                                                   @Param("now") LocalDateTime now,
@@ -94,52 +94,52 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
 
 
     @Query("""
-    select
-        e as event,
-        coalesce(sum(v.cnt), 0) as views14,
-        count(distinct eb.id) as bookmarksCnt,
-        (
-            coalesce(sum(v.cnt), 0) * 0.6
-          + count(distinct eb.id) * 0.3
-          + (
-                case when coalesce(sum(v.cnt), 0) > 0
-                     then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
-                     else 0
-                end
-            ) * 0.1
-        ) as popularity
-    from Event e
-    left join EventViewDaily v
-           on v.event = e and v.createdAt >= :since
-    left join EventBookmark eb
-           on eb.event = e and eb.createdAt >= :since
-    left join EventAction ea
-           on ea.event = e and ea.createdAt >= :since and ea.actionType = 'APPLY'
-    where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-      and (e.eventEnd is null or e.eventEnd >= :now)
-      and e.recruitEnd is not null
-      and e.recruitEnd between :now and :due
-      and (
-            :roleName is null
-            or exists (
-                select 1
-                from Event e2 join e2.targetRoles tr2
-                where e2 = e and tr2.name = :roleName
-            )
-      )
-    group by e
-    order by
-          (
-            coalesce(sum(v.cnt), 0) * 0.6
-            + count(distinct eb.id) * 0.3
-            + (
-                case when coalesce(sum(v.cnt), 0) > 0
-                     then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
-                     else 0
-                end
-            ) * 0.1
-        ) desc, e.recruitEnd asc, e.createdAt desc
-    """)
+            select
+                e as event,
+                coalesce(sum(v.cnt), 0) as views14,
+                count(distinct eb.id) as bookmarksCnt,
+                (
+                    coalesce(sum(v.cnt), 0) * 0.6
+                  + count(distinct eb.id) * 0.3
+                  + (
+                        case when coalesce(sum(v.cnt), 0) > 0
+                             then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
+                             else 0
+                        end
+                    ) * 0.1
+                ) as popularity
+            from Event e
+            left join EventViewDaily v
+                   on v.event = e and v.createdAt >= :since
+            left join EventBookmark eb
+                   on eb.event = e and eb.createdAt >= :since
+            left join EventAction ea
+                   on ea.event = e and ea.createdAt >= :since and ea.actionType = 'APPLY'
+            where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+              and (e.eventEnd is null or e.eventEnd >= :now)
+              and e.recruitEnd is not null
+              and e.recruitEnd between :now and :due
+              and (
+                    :roleName is null
+                    or exists (
+                        select 1
+                        from Event e2 join e2.targetRoles tr2
+                        where e2 = e and tr2.name = :roleName
+                    )
+              )
+            group by e
+            order by
+                  (
+                    coalesce(sum(v.cnt), 0) * 0.6
+                    + count(distinct eb.id) * 0.3
+                    + (
+                        case when coalesce(sum(v.cnt), 0) > 0
+                             then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
+                             else 0
+                        end
+                    ) * 0.1
+                ) desc, e.recruitEnd asc, e.createdAt desc
+            """)
     List<PopularEventProjection> findClosingSoonForHomeWithPopularity(@Param("roleName") String roleName,
                                                                       @Param("since") LocalDateTime since,
                                                                       @Param("now") LocalDateTime now,
@@ -147,53 +147,53 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
                                                                       Pageable pageable);
 
     @Query("""
-    select
-        e as event,
-        coalesce(sum(v.cnt), 0) as views14,
-        count(distinct eb.id) as bookmarksCnt,
-        (
-            coalesce(sum(v.cnt), 0) * 0.6
-          + count(distinct eb.id) * 0.3
-          + (
-                case when coalesce(sum(v.cnt), 0) > 0
-                     then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
-                     else 0
-                end
-            ) * 0.1
-        ) as popularity
-    from Event e
-    left join EventViewDaily v
-           on v.event = e and v.createdAt >= :since
-    left join EventBookmark eb
-           on eb.event = e
-    left join EventAction ea
-           on ea.event = e and ea.createdAt >= :since and ea.actionType = 'APPLY'
-    where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-      and e.category = com.example.skillup.domain.event.enums.EventCategory.BOOTCAMP_CLUB
-      and (e.eventEnd is null or e.eventEnd >= :now)
-      and e.recruitEnd is not null
-      and e.recruitEnd >= :now
-      and (
-            :roleName is null
-            or exists (
-                select 1
-                from Event e2 join e2.targetRoles tr2
-                where e2 = e and tr2.name = :roleName
-            )
-      )
-    group by e
-    order by
-          (
-            coalesce(sum(v.cnt), 0) * 0.6
-            + count(distinct eb.id) * 0.3
-            + (
-                case when coalesce(sum(v.cnt), 0) > 0
-                     then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
-                     else 0
-                end
-            ) * 0.1
-        ) desc, e.recruitEnd asc, e.createdAt desc
-    """)
+            select
+                e as event,
+                coalesce(sum(v.cnt), 0) as views14,
+                count(distinct eb.id) as bookmarksCnt,
+                (
+                    coalesce(sum(v.cnt), 0) * 0.6
+                  + count(distinct eb.id) * 0.3
+                  + (
+                        case when coalesce(sum(v.cnt), 0) > 0
+                             then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
+                             else 0
+                        end
+                    ) * 0.1
+                ) as popularity
+            from Event e
+            left join EventViewDaily v
+                   on v.event = e and v.createdAt >= :since
+            left join EventBookmark eb
+                   on eb.event = e
+            left join EventAction ea
+                   on ea.event = e and ea.createdAt >= :since and ea.actionType = 'APPLY'
+            where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+              and e.category = com.example.skillup.domain.event.enums.EventCategory.BOOTCAMP_CLUB
+              and (e.eventEnd is null or e.eventEnd >= :now)
+              and e.recruitEnd is not null
+              and e.recruitEnd >= :now
+              and (
+                    :roleName is null
+                    or exists (
+                        select 1
+                        from Event e2 join e2.targetRoles tr2
+                        where e2 = e and tr2.name = :roleName
+                    )
+              )
+            group by e
+            order by
+                  (
+                    coalesce(sum(v.cnt), 0) * 0.6
+                    + count(distinct eb.id) * 0.3
+                    + (
+                        case when coalesce(sum(v.cnt), 0) > 0
+                             then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
+                             else 0
+                        end
+                    ) * 0.1
+                ) desc, e.recruitEnd asc, e.createdAt desc
+            """)
     List<PopularEventProjection> findBootcampsOpenOrderByPopularityWithPopularity(@Param("since") LocalDateTime since,
                                                                                   @Param("now") LocalDateTime now,
                                                                                   @Param("roleName") String roleName,
@@ -201,59 +201,60 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
 
 
     @Query("""
-    select
-        e as event,
-        coalesce(sum(v.cnt), 0) as views14,
-        count(distinct eb.id) as bookmarksCnt,
-        (
-            coalesce(sum(v.cnt), 0) * 0.6
-          + count(distinct eb.id) * 0.3
-          + (
-                case when coalesce(sum(v.cnt), 0) > 0
-                     then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
-                     else 0
-                end
-            ) * 0.1
-        ) as popularity
-    from Event e
-    left join EventViewDaily v
-           on v.event = e and v.createdAt >= :since
-    left join EventBookmark eb
-           on eb.event = e
-    left join EventAction ea
-           on ea.event = e and ea.createdAt >= :since and ea.actionType = 'APPLY'
-    where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-      and e.category = :category
-      and (e.eventEnd is null or e.eventEnd >= :now)
-      and e.recruitEnd is not null
-      and e.recruitEnd between :now and :due
-    group by e
-    order by
-           (
-            coalesce(sum(v.cnt), 0) * 0.6
-            + count(distinct eb.id) * 0.3
-            + (
-                case when coalesce(sum(v.cnt), 0) > 0
-                     then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
-                     else 0
-                end
-            ) * 0.1
-        ) desc, e.recruitEnd asc, e.createdAt desc
-    """)
-    List<PopularEventProjection> findByCategoryWithin30DaysOrderByPopularityWithPopularity(@Param("category") EventCategory category,
-                                                                                           @Param("since") LocalDateTime since,
-                                                                                           @Param("now") LocalDateTime now,
-                                                                                           @Param("due") LocalDateTime due,
-                                                                                           Pageable pageable);
+            select
+                e as event,
+                coalesce(sum(v.cnt), 0) as views14,
+                count(distinct eb.id) as bookmarksCnt,
+                (
+                    coalesce(sum(v.cnt), 0) * 0.6
+                  + count(distinct eb.id) * 0.3
+                  + (
+                        case when coalesce(sum(v.cnt), 0) > 0
+                             then (1.0 * count(distinct ea.id) / coalesce(sum(v.cnt), 0))
+                             else 0
+                        end
+                    ) * 0.1
+                ) as popularity
+            from Event e
+            left join EventViewDaily v
+                   on v.event = e and v.createdAt >= :since
+            left join EventBookmark eb
+                   on eb.event = e
+            left join EventAction ea
+                   on ea.event = e and ea.createdAt >= :since and ea.actionType = 'APPLY'
+            where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+              and e.category = :category
+              and (e.eventEnd is null or e.eventEnd >= :now)
+              and e.recruitEnd is not null
+              and e.recruitEnd between :now and :due
+            group by e
+            order by
+                   (
+                    coalesce(sum(v.cnt), 0) * 0.6
+                    + count(distinct eb.id) * 0.3
+                    + (
+                        case when coalesce(sum(v.cnt), 0) > 0
+                             then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
+                             else 0
+                        end
+                    ) * 0.1
+                ) desc, e.recruitEnd asc, e.createdAt desc
+            """)
+    List<PopularEventProjection> findByCategoryWithin30DaysOrderByPopularityWithPopularity(
+            @Param("category") EventCategory category,
+            @Param("since") LocalDateTime since,
+            @Param("now") LocalDateTime now,
+            @Param("due") LocalDateTime due,
+            Pageable pageable);
 
     @Query("""
-        select e
-        from Event e
-        where (:category = com.example.skillup.domain.event.enums.EventCategory.ALL or e.category = :category)
-          and (:keyword is null or lower(e.title) like lower(concat('%', :keyword, '%')))
-          and (:includeEnded = true or e.eventEnd >= :now)
-          and (e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED)
-    """)
+                select e
+                from Event e
+                where (:category = com.example.skillup.domain.event.enums.EventCategory.ALL or e.category = :category)
+                  and (:keyword is null or lower(e.title) like lower(concat('%', :keyword, '%')))
+                  and (:includeEnded = true or e.eventEnd >= :now)
+                  and (e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED)
+            """)
     Page<Event> findAdminEvents(
             @Param("includeEnded") boolean includeEnded,
             @Param("category") EventCategory category,
@@ -264,38 +265,38 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
 
 
     @Query("""
-    select
-      coalesce(sum(case
-        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-        then 1 else 0 end), 0) as totalRegistered,
-
-      coalesce(sum(case
-        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-             and e.recruitStart > :now
-        then 1 else 0 end), 0) as recruitingScheduled,
-
-      coalesce(sum(case
-        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-             and e.recruitStart <= :now and :now <= e.recruitEnd
-        then 1 else 0 end), 0) as recruiting,
-
-      coalesce(sum(case
-        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-             and e.recruitEnd < :now and e.eventEnd >= :now
-        then 1 else 0 end), 0) as recruitingClosed,
-
-      coalesce(sum(case
-        when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-             and e.eventStart <= :now and e.eventEnd >= :now
-        then 1 else 0 end), 0) as ongoing,
-        
-      coalesce(sum(case
-        when e.status = com.example.skillup.domain.event.enums.EventStatus.DRAFT
-        then 1 else 0 end), 0) as creatableCount
-
-    from Event e
-    where (:includeEnded = true or e.eventEnd >= :now) 
-""")
+                select
+                  coalesce(sum(case
+                    when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+                    then 1 else 0 end), 0) as totalRegistered,
+            
+                  coalesce(sum(case
+                    when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+                         and e.recruitStart > :now
+                    then 1 else 0 end), 0) as recruitingScheduled,
+            
+                  coalesce(sum(case
+                    when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+                         and e.recruitStart <= :now and :now <= e.recruitEnd
+                    then 1 else 0 end), 0) as recruiting,
+            
+                  coalesce(sum(case
+                    when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+                         and e.recruitEnd < :now and e.eventEnd >= :now
+                    then 1 else 0 end), 0) as recruitingClosed,
+            
+                  coalesce(sum(case
+                    when e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+                         and e.eventStart <= :now and e.eventEnd >= :now
+                    then 1 else 0 end), 0) as ongoing,
+            
+                  coalesce(sum(case
+                    when e.status = com.example.skillup.domain.event.enums.EventStatus.DRAFT
+                    then 1 else 0 end), 0) as creatableCount
+            
+                from Event e
+                where (:includeEnded = true or e.eventEnd >= :now) 
+            """)
     AdminEventSummaryProjection fetchAdminSummary(
             @Param("includeEnded") boolean includeEnded,
             @Param("now") LocalDateTime now
@@ -308,21 +309,26 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
 
     public interface AdminEventSummaryProjection {
         long getTotalRegistered();
+
         long getRecruitingScheduled();
+
         long getRecruiting();
+
         long getRecruitingClosed();
+
         long getOngoing();
+
         long getCreatableCount();
     }
 
     @Query("""
-    select e.category as category, count(e) as count
-    from Event e
-    where (:includeEnded = true or e.eventEnd is null or e.eventEnd >= :now)
-      and (:keyword is null or lower(e.title) like lower(concat('%', :keyword, '%')))
-      and (e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED)
-    group by e.category
-""")
+                select e.category as category, count(e) as count
+                from Event e
+                where (:includeEnded = true or e.eventEnd is null or e.eventEnd >= :now)
+                  and (:keyword is null or lower(e.title) like lower(concat('%', :keyword, '%')))
+                  and (e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED)
+                group by e.category
+            """)
     List<AdminCategoryCountProjection> fetchAdminCategoryCounts(
             @Param("includeEnded") boolean includeEnded,
             @Param("keyword") String keyword,
@@ -331,104 +337,105 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
 
     public interface AdminCategoryCountProjection {
         EventCategory getCategory();
+
         long getCount();
     }
 
 
-
-
-
     public interface PopularEventProjection {
         Event getEvent();
+
         Long getViews14();
+
         Long getBookmarksCnt();
+
         Double getPopularity();
     }
 
     @Query(value = """
-SELECT e.*
-FROM `event` e
-JOIN event_hash_tags eht ON e.id = eht.event_id
-JOIN (
-    SELECT activity_tag_weights.hash_tags_id,
-           SUM(activity_tag_weights.weight) AS score
-    FROM (
-        SELECT eht2.hash_tags_id AS hash_tags_id,
-               0.3E0 AS weight
-        FROM event_action ea
-        JOIN event_hash_tags eht2 ON ea.event_id = eht2.event_id
-        WHERE ea.actor_id = :actorId
-          AND ea.created_at >= :since
-          AND ea.action_type = 'VIEW'
-
-        UNION ALL
-
-        -- 북마크 점수 환산
-        SELECT eht3.hash_tags_id AS hash_tags_id,
-               0.6E0 AS weight
-        FROM event_bookmark eb
-        JOIN event_hash_tags eht3 ON eb.event_id = eht3.event_id
-        WHERE eb.user_id = :userId
-          AND eb.deleted_at IS NULL
-          AND eb.is_bookmarked = true
-          AND eb.updated_at >= :since
-
-        UNION ALL
-
-        SELECT eht4.hash_tags_id AS hash_tags_id,
-               0.1E0 AS weight
-        FROM event_action ea2
-        JOIN event_hash_tags eht4 ON ea2.event_id = eht4.event_id
-        WHERE ea2.actor_id = :actorId
-          AND ea2.created_at >= :since
-          AND ea2.action_type = 'APPLY'
-    ) AS activity_tag_weights
-    GROUP BY activity_tag_weights.hash_tags_id
-    ORDER BY score DESC
-    LIMIT 10
-) AS top_tags ON eht.hash_tags_id = top_tags.hash_tags_id
-WHERE e.id NOT IN (
-    -- 북마크 및 이미 보거나 신청한 행사 제외
-    SELECT ea3.event_id
-    FROM event_action ea3
-    WHERE ea3.actor_id = :actorId
-
-    UNION
-
-    SELECT eb2.event_id
-    FROM event_bookmark eb2
-    WHERE eb2.user_id = :userId
-      AND eb2.deleted_at IS NULL
-      AND eb2.is_bookmarked = true
-)
-GROUP BY e.id
-ORDER BY SUM(top_tags.score) DESC
-LIMIT 6
-""", nativeQuery = true)
-    List<Event> findRecommendedEventForHome( @Param("actorId") String actorId,@Param("userId") Long userId ,@Param("since") LocalDateTime since);
-
+            SELECT e.*
+            FROM `event` e
+            JOIN event_hash_tags eht ON e.id = eht.event_id
+            JOIN (
+                SELECT activity_tag_weights.hash_tags_id,
+                       SUM(activity_tag_weights.weight) AS score
+                FROM (
+                    SELECT eht2.hash_tags_id AS hash_tags_id,
+                           0.3E0 AS weight
+                    FROM event_action ea
+                    JOIN event_hash_tags eht2 ON ea.event_id = eht2.event_id
+                    WHERE ea.actor_id = :actorId
+                      AND ea.created_at >= :since
+                      AND ea.action_type = 'VIEW'
+            
+                    UNION ALL
+            
+                    -- 북마크 점수 환산
+                    SELECT eht3.hash_tags_id AS hash_tags_id,
+                           0.6E0 AS weight
+                    FROM event_bookmark eb
+                    JOIN event_hash_tags eht3 ON eb.event_id = eht3.event_id
+                    WHERE eb.user_id = :userId
+                      AND eb.deleted_at IS NULL
+                      AND eb.is_bookmarked = true
+                      AND eb.updated_at >= :since
+            
+                    UNION ALL
+            
+                    SELECT eht4.hash_tags_id AS hash_tags_id,
+                           0.1E0 AS weight
+                    FROM event_action ea2
+                    JOIN event_hash_tags eht4 ON ea2.event_id = eht4.event_id
+                    WHERE ea2.actor_id = :actorId
+                      AND ea2.created_at >= :since
+                      AND ea2.action_type = 'APPLY'
+                ) AS activity_tag_weights
+                GROUP BY activity_tag_weights.hash_tags_id
+                ORDER BY score DESC
+                LIMIT 10
+            ) AS top_tags ON eht.hash_tags_id = top_tags.hash_tags_id
+            WHERE e.id NOT IN (
+                -- 북마크 및 이미 보거나 신청한 행사 제외
+                SELECT ea3.event_id
+                FROM event_action ea3
+                WHERE ea3.actor_id = :actorId
+            
+                UNION
+            
+                SELECT eb2.event_id
+                FROM event_bookmark eb2
+                WHERE eb2.user_id = :userId
+                  AND eb2.deleted_at IS NULL
+                  AND eb2.is_bookmarked = true
+            )
+            GROUP BY e.id
+            ORDER BY SUM(top_tags.score) DESC
+            LIMIT 6
+            """, nativeQuery = true)
+    List<Event> findRecommendedEventForHome(@Param("actorId") String actorId, @Param("userId") Long userId,
+                                            @Param("since") LocalDateTime since);
 
 
     @Query(value = """
-    SELECT COUNT(*)
-    FROM (
-        SELECT e.id
-        FROM event e
-        LEFT JOIN event_target_role etr ON etr.event_id = e.id
-        LEFT JOIN target_role tr ON tr.id = etr.role_id
-        WHERE (:category IS NULL OR e.category = :category)
-          AND (e.event_end IS NULL OR e.event_end >= :now)
-          AND (e.status = 'PUBLISHED')
-          AND (:isOnline IS NULL OR e.is_online = :isOnline)
-          AND (:isFree IS NULL OR e.is_free = :isFree)
-          AND (:startDate IS NULL OR e.event_start BETWEEN :startDate AND :endDate)
-          AND (
-                :targetRolesIsEmpty = TRUE
-                OR tr.name = :targetRole
-          )
-        GROUP BY e.id
-    ) AS counted
-""", nativeQuery = true)
+                SELECT COUNT(*)
+                FROM (
+                    SELECT e.id
+                    FROM event e
+                    LEFT JOIN event_target_role etr ON etr.event_id = e.id
+                    LEFT JOIN target_role tr ON tr.id = etr.role_id
+                    WHERE (:category IS NULL OR e.category = :category)
+                      AND (e.event_end IS NULL OR e.event_end >= :now)
+                      AND (e.status = 'PUBLISHED')
+                      AND (:isOnline IS NULL OR e.is_online = :isOnline)
+                      AND (:isFree IS NULL OR e.is_free = :isFree)
+                      AND (:startDate IS NULL OR e.event_start BETWEEN :startDate AND :endDate)
+                      AND (
+                            :targetRolesIsEmpty = TRUE
+                            OR tr.name = :targetRole
+                      )
+                    GROUP BY e.id
+                ) AS counted
+            """, nativeQuery = true)
     int countByCategoryWithSearch(
             @Param("category") String category,
             @Param("isOnline") Boolean isOnline,
@@ -441,74 +448,73 @@ LIMIT 6
     );
 
 
-
     // 위에는 점수까지 포함(test 용) 아래는 점수 포함하지 않은 쿼리문
     @Query("""
-    select e
-    from Event e
-    left join EventViewDaily v
-           on v.event = e and v.createdAt >= :since
-    left join EventLike el
-           on el.event = e
-    where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-      and (e.eventEnd is null or e.eventEnd >= :now)
-      and (
-            :roleName is null
-            or exists (
-                select 1
-                from Event e2 join e2.targetRoles tr2
-                where e2 = e and tr2.name = :roleName
-            )
-      )
-    group by e
-    order by
-        coalesce(sum(v.cnt), 0) * 0.6
-      + count(distinct el.id) * 0.3
-      + (
-            case when coalesce(sum(v.cnt), 0) > 0
-                 then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
-                 else 0
-            end
-        ) * 0.1
-      desc , e.createdAt desc
-    """)
+            select e
+            from Event e
+            left join EventViewDaily v
+                   on v.event = e and v.createdAt >= :since
+            left join EventLike el
+                   on el.event = e
+            where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+              and (e.eventEnd is null or e.eventEnd >= :now)
+              and (
+                    :roleName is null
+                    or exists (
+                        select 1
+                        from Event e2 join e2.targetRoles tr2
+                        where e2 = e and tr2.name = :roleName
+                    )
+              )
+            group by e
+            order by
+                coalesce(sum(v.cnt), 0) * 0.6
+              + count(distinct el.id) * 0.3
+              + (
+                    case when coalesce(sum(v.cnt), 0) > 0
+                         then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
+                         else 0
+                    end
+                ) * 0.1
+              desc , e.createdAt desc
+            """)
     List<Event> findPopularForHome(@Param("roleName") String roleName,
                                    @Param("since") LocalDate since,
                                    @Param("now") LocalDateTime now,
                                    Pageable pageable);
 
     @Query("""
-    select e
-    from Event e
-    left join EventViewDaily v
-           on v.event = e and v.createdAt >= :since
-    left join EventLike el
-           on el.event = e
-    where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-      and (e.eventEnd is null or e.eventEnd >= :now)
-      and e.recruitEnd is not null
-      and e.recruitEnd between :now and :due
-      and (
-            :roleName is null
-            or exists (
-                select 1
-                from Event e2 join e2.targetRoles tr2
-                where e2 = e and tr2.name = :roleName
-            )
-      )
-    group by e
-    order by
-        coalesce(sum(v.cnt), 0) * 0.6
-      + count(distinct el.id) * 0.3
-      + (
-            case when coalesce(sum(v.cnt), 0) > 0
-                 then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
-                 else 0
-            end
-        ) * 0.1
-      desc,
-      e.createdAt desc
-    """)
+            select e
+            from Event e
+            left join EventViewDaily v
+                   on v.event = e and v.createdAt >= :since
+            left join EventLike el
+                   on el.event = e
+            where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+              and (e.eventEnd is null or e.eventEnd >= :now)
+              and e.recruitEnd is not null
+              and e.recruitEnd between :now and :due
+              and (
+                    :roleName is null
+                    or exists (
+                        select 1
+                        from Event e2 join e2.targetRoles tr2
+                        where e2 = e and tr2.name = :roleName
+                    )
+              )
+            group by e
+            order by
+                coalesce(sum(v.cnt), 0) * 0.6
+              + count(distinct el.id) * 0.3
+              + (
+                    case when coalesce(sum(v.cnt), 0) > 0
+                         then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
+                         else 0
+                    end
+                ) * 0.1
+              desc,
+              e.createdAt desc
+            """)
     List<Event> findClosingSoonForHome(@Param("roleName") String roleName,
                                        @Param("since") LocalDate since,
                                        @Param("now") LocalDateTime now,
@@ -516,61 +522,61 @@ LIMIT 6
                                        Pageable pageable);
 
     @Query("""
-    select e
-    from Event e
-    left join EventViewDaily v
-           on v.event = e and v.createdAt >= :since
-    left join EventLike el
-           on el.event = e
-    where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-      and e.category = com.example.skillup.domain.event.enums.EventCategory.BOOTCAMP_CLUB
-      and (e.eventEnd is null or e.eventEnd >= :now)
-      and e.recruitEnd is not null
-      and e.recruitEnd >= :now
-    group by e
-    order by
-        coalesce(sum(v.cnt), 0) * 0.6
-      + count(distinct el.id) * 0.3
-      + (
-            case when coalesce(sum(v.cnt), 0) > 0
-                 then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
-                 else 0
-            end
-        ) * 0.1
-      desc,
-      e.recruitEnd asc,
-      e.createdAt desc
-    """)
+            select e
+            from Event e
+            left join EventViewDaily v
+                   on v.event = e and v.createdAt >= :since
+            left join EventLike el
+                   on el.event = e
+            where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+              and e.category = com.example.skillup.domain.event.enums.EventCategory.BOOTCAMP_CLUB
+              and (e.eventEnd is null or e.eventEnd >= :now)
+              and e.recruitEnd is not null
+              and e.recruitEnd >= :now
+            group by e
+            order by
+                coalesce(sum(v.cnt), 0) * 0.6
+              + count(distinct el.id) * 0.3
+              + (
+                    case when coalesce(sum(v.cnt), 0) > 0
+                         then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
+                         else 0
+                    end
+                ) * 0.1
+              desc,
+              e.recruitEnd asc,
+              e.createdAt desc
+            """)
     List<Event> findBootcampsOpenOrderByPopularity(@Param("since") LocalDate since,
                                                    @Param("now") LocalDateTime now,
                                                    Pageable pageable);
 
     @Query("""
-    select e
-    from Event e
-    left join EventViewDaily v
-           on v.event = e and v.createdAt >= :since
-    left join EventLike el
-           on el.event = e
-    where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
-      and e.category = :category
-      and (e.eventEnd is null or e.eventEnd >= :now)
-      and e.recruitEnd is not null
-      and e.recruitEnd between :now and :due
-    group by e
-    order by
-        coalesce(sum(v.cnt), 0) * 0.6
-      + count(distinct el.id) * 0.3
-      + (
-            case when coalesce(sum(v.cnt), 0) > 0
-                 then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
-                 else 0
-            end
-        ) * 0.1
-      desc,
-      e.recruitEnd asc,
-      e.createdAt desc
-    """)
+            select e
+            from Event e
+            left join EventViewDaily v
+                   on v.event = e and v.createdAt >= :since
+            left join EventLike el
+                   on el.event = e
+            where e.status = com.example.skillup.domain.event.enums.EventStatus.PUBLISHED
+              and e.category = :category
+              and (e.eventEnd is null or e.eventEnd >= :now)
+              and e.recruitEnd is not null
+              and e.recruitEnd between :now and :due
+            group by e
+            order by
+                coalesce(sum(v.cnt), 0) * 0.6
+              + count(distinct el.id) * 0.3
+              + (
+                    case when coalesce(sum(v.cnt), 0) > 0
+                         then (1.0 * e.applyClicks / coalesce(sum(v.cnt), 0))
+                         else 0
+                    end
+                ) * 0.1
+              desc,
+              e.recruitEnd asc,
+              e.createdAt desc
+            """)
     List<Event> findByCategoryWithin30DaysOrderByPopularity(@Param("category") EventCategory category,
                                                             @Param("since") LocalDate since,
                                                             @Param("now") LocalDateTime now,

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -80,8 +80,6 @@ public class EventService {
     LocalDateTime now = LocalDateTime.now();
 
 
-
-
     private record ActorInfo(String actorId, ActorType actorType) {
     }
 
@@ -122,11 +120,11 @@ public class EventService {
             thumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
         }
 
-
         GeoPoint eventGeoPoint = null;
         if (!request.getIsOnline()) {
             eventGeoPoint = geocodingService.geocode(request.getLocationText());
-            log.info("위도 : {} , 경도 : {} , 도로명 주소 : {} ", eventGeoPoint.lat(), eventGeoPoint.lng(), eventGeoPoint.roadAddress());
+            log.info("위도 : {} , 경도 : {} , 도로명 주소 : {} ", eventGeoPoint.lat(), eventGeoPoint.lng(),
+                    eventGeoPoint.roadAddress());
         }
 
         Event event = eventMapper.toEntity(request, thumbnailUrl, eventGeoPoint);
@@ -184,7 +182,8 @@ public class EventService {
 
         event.update(request, imageUrl);
 
-        boolean locationChanged = request.getLocationText() != null && !request.getLocationText().equals(oldLocationText);
+        boolean locationChanged =
+                request.getLocationText() != null && !request.getLocationText().equals(oldLocationText);
 
         boolean onlineChanged = request.getIsOnline() != null && !request.getIsOnline().equals(oldIsOnline);
 
@@ -465,7 +464,7 @@ public class EventService {
     @Transactional(readOnly = true)
     @HandleDataAccessException
     public List<EventResponse.HomeEventResponse> getRecommendedEvents(Long actorId, UsersDetails user) {
-        List<Event> events = eventRepository.findRecommendedEventForHome(actorId.toString(), actorId , since);
+        List<Event> events = eventRepository.findRecommendedEventForHome(actorId.toString(), actorId, since);
 
         List<Long> eventIds = events.stream().map(Event::getId).toList();
         Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, eventIds);
@@ -477,7 +476,7 @@ public class EventService {
     @HandleDataAccessException
     public List<EventResponse.HomeEventResponse> getRecentEvents(String actorId, UsersDetails user) {
         Pageable pageable = PageRequest.of(0, 10);
-        List<Event> events = eventActionRepository.findRecentEventsByActorId(actorId, pageable , ActionType.VIEW);
+        List<Event> events = eventActionRepository.findRecentEventsByActorId(actorId, pageable, ActionType.VIEW);
 
         List<Long> eventIds = events.stream().map(Event::getId).toList();
         Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, eventIds);
@@ -544,33 +543,37 @@ public class EventService {
     public AdminEventPageResponse getAdminEventPage(AdminEventPageRequest request) {
 
         String keyword = request.getKeyword();
-        if(keyword != null) {
+        if (keyword != null) {
             keyword = keyword.trim();
             keyword = keyword.isEmpty() ? null : keyword;
         }
 
         int page = request.getPage();
-        Pageable pageable = PageRequest.of(page, 20 , toSpringSort(request.getSort()));
+        Pageable pageable = PageRequest.of(page, 20, toSpringSort(request.getSort()));
         //검색 결과 표시용 event
-        Page<Event> result = eventRepository.findAdminEvents(request.getIncludeEnded(), request.getCategory(), keyword, now, pageable);
+        Page<Event> result = eventRepository.findAdminEvents(request.getIncludeEnded(), request.getCategory(), keyword,
+                now, pageable);
 
-        List<EventResponse.AdminEventRow> rows = eventMapper.toAdminEventRowList(result.getContent() , page , 20 ,
+        List<EventResponse.AdminEventRow> rows = eventMapper.toAdminEventRowList(result.getContent(), page, 20,
                 result.getTotalElements(), now);
-        CommonResponse.PageInfoResponse pageInfoResponse = CommonMapper.toPageInfoResponse(pageable , page , (int)result.getTotalElements());
-
+        CommonResponse.PageInfoResponse pageInfoResponse = CommonMapper.toPageInfoResponse(pageable, page,
+                (int) result.getTotalElements());
 
         log.info("total elements: {}", result.getTotalElements());
 
         //상단바
         AdminEventSummaryProjection countSummary = eventRepository.fetchAdminSummary(request.getIncludeEnded(), now);
         //검색 결과 상단바
-        List<AdminCategoryCountProjection> categoryCount = eventRepository.fetchAdminCategoryCounts(request.getIncludeEnded() , keyword , now);
+        List<AdminCategoryCountProjection> categoryCount = eventRepository.fetchAdminCategoryCounts(
+                request.getIncludeEnded(), keyword, now);
 
-        return eventMapper.toAdminEventPageResponse(rows , countSummary , categoryCount ,pageInfoResponse);
+        return eventMapper.toAdminEventPageResponse(rows, countSummary, categoryCount, pageInfoResponse);
     }
 
     private Sort toSpringSort(EventSortType sortType) {
-        if (sortType == null) return Sort.by(Sort.Direction.ASC, "eventStart");
+        if (sortType == null) {
+            return Sort.by(Sort.Direction.ASC, "eventStart");
+        }
 
         return switch (sortType) {
             case EVENT_START -> Sort.by(Sort.Direction.ASC, "eventStart");
@@ -578,7 +581,7 @@ public class EventService {
             case BOOKMARKS -> Sort.by(Sort.Direction.DESC, "bookmarkedCount");
             case CREATED_AT -> Sort.by(Sort.Direction.DESC, "createdAt");
 
-            default -> throw new EventException(EventErrorCode.INVALID_EVENT_SORT_TYPE , sortType.name() +"은 ");
+            default -> throw new EventException(EventErrorCode.INVALID_EVENT_SORT_TYPE, sortType.name() + "은 ");
         };
     }
 
@@ -588,7 +591,7 @@ public class EventService {
             case DEADLINE -> eventRepository.findTop200ByStatusOrderByRecruitEndAsc(EventStatus.DRAFT);
             case CREATED_AT -> eventRepository.findTop200ByStatusOrderByCreatedAtDesc(EventStatus.DRAFT);
 
-            default -> throw new EventException(EventErrorCode.INVALID_EVENT_SORT_TYPE , sortType.name() +"은 ");
+            default -> throw new EventException(EventErrorCode.INVALID_EVENT_SORT_TYPE, sortType.name() + "은 ");
         };
 
         return eventMapper.toAdminDraftEventRowList(events);

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -1,7 +1,9 @@
 package com.example.skillup.domain.event.service;
 
 import com.example.skillup.domain.event.dto.request.EventRequest;
+import com.example.skillup.domain.event.dto.request.EventRequest.AdminEventPageRequest;
 import com.example.skillup.domain.event.dto.response.EventResponse;
+import com.example.skillup.domain.event.dto.response.EventResponse.AdminEventPageResponse;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventAction;
 import com.example.skillup.domain.event.entity.EventLike;
@@ -17,6 +19,8 @@ import com.example.skillup.domain.event.repository.EventActionRepository;
 import com.example.skillup.domain.event.repository.EventBookmarkRepository;
 import com.example.skillup.domain.event.repository.EventLikeRepository;
 import com.example.skillup.domain.event.repository.EventRepository;
+import com.example.skillup.domain.event.repository.EventRepository.AdminCategoryCountProjection;
+import com.example.skillup.domain.event.repository.EventRepository.AdminEventSummaryProjection;
 import com.example.skillup.domain.event.repository.EventRepositoryImpl;
 import com.example.skillup.domain.map.provider.GeocodingProvider.GeoPoint;
 import com.example.skillup.domain.map.service.GeocodingService;
@@ -26,6 +30,8 @@ import com.example.skillup.domain.user.entity.UsersDetails;
 import com.example.skillup.domain.user.repository.GuestRepository;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.aop.HandleDataAccessException;
+import com.example.skillup.global.common.CommonMapper;
+import com.example.skillup.global.common.CommonResponse;
 import com.example.skillup.global.enums.JobGroup;
 import com.example.skillup.global.exception.CommonErrorCode;
 import com.example.skillup.global.search.service.EventIndexerService;
@@ -42,8 +48,10 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -69,6 +77,8 @@ public class EventService {
 
     LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
     LocalDateTime now = LocalDateTime.now();
+
+
 
     private record ActorInfo(String actorId, ActorType actorType) {
     }
@@ -525,5 +535,48 @@ public class EventService {
             bookmarkedEventIds.addAll(eventBookmarkRepository.findBookmarkedEventIds(user.getUser().getId(), eventIds));
         }
         return bookmarkedEventIds;
+    }
+
+
+    @Transactional(readOnly = true)
+    public AdminEventPageResponse getAdminEventPage(AdminEventPageRequest request) {
+
+        String keyword = request.getKeyword();
+        if(keyword != null) {
+            keyword = keyword.trim();
+            keyword = keyword.isEmpty() ? null : keyword;
+        }
+
+        int page = request.getPage();
+        Pageable pageable = PageRequest.of(page, 20 , toSpringSort(request.getSort()));
+        //검색 결과 표시용 event
+        Page<Event> result = eventRepository.findAdminEvents(request.getIncludeEnded(), request.getCategory(), keyword, now, pageable);
+
+        List<EventResponse.AdminEventRow> rows = eventMapper.toAdminEventRowList(result.getContent() , page , 20 ,
+                result.getTotalElements(), now);
+        CommonResponse.PageInfoResponse pageInfoResponse = CommonMapper.toPageInfoResponse(pageable , page , (int)result.getTotalElements());
+
+
+        log.info("total elements: {}", result.getTotalElements());
+
+        //상단바
+        AdminEventSummaryProjection countSummary = eventRepository.fetchAdminSummary(request.getIncludeEnded(), now);
+        //검색 결과 상단바
+        List<AdminCategoryCountProjection> categoryCount = eventRepository.fetchAdminCategoryCounts(request.getIncludeEnded() , keyword , now);
+
+        return eventMapper.toAdminEventPageResponse(rows , countSummary , categoryCount ,pageInfoResponse);
+    }
+
+    private Sort toSpringSort(EventSortType sortType) {
+        if (sortType == null) return Sort.by(Sort.Direction.ASC, "eventStart");
+
+        return switch (sortType) {
+            case EVENT_START -> Sort.by(Sort.Direction.ASC, "eventStart");
+            case VIEWS -> Sort.by(Sort.Direction.DESC, "viewsCount");
+            case BOOKMARKS -> Sort.by(Sort.Direction.DESC, "bookmarkedCount");
+            case CREATED_AT -> Sort.by(Sort.Direction.DESC, "createdAt");
+
+            default -> throw new EventException(EventErrorCode.INVALID_EVENT_SORT_TYPE , sortType.name() +"은 ");
+        };
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -3,6 +3,7 @@ package com.example.skillup.domain.event.service;
 import com.example.skillup.domain.event.dto.request.EventRequest;
 import com.example.skillup.domain.event.dto.request.EventRequest.AdminEventPageRequest;
 import com.example.skillup.domain.event.dto.response.EventResponse;
+import com.example.skillup.domain.event.dto.response.EventResponse.AdminDraftEventResponse;
 import com.example.skillup.domain.event.dto.response.EventResponse.AdminEventPageResponse;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventAction;
@@ -77,6 +78,7 @@ public class EventService {
 
     LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
     LocalDateTime now = LocalDateTime.now();
+
 
 
 
@@ -578,5 +580,17 @@ public class EventService {
 
             default -> throw new EventException(EventErrorCode.INVALID_EVENT_SORT_TYPE , sortType.name() +"은 ");
         };
+    }
+
+    public AdminDraftEventResponse getAdminDraftEvents(EventSortType sortType) {
+
+        List<Event> events = switch (sortType) {
+            case DEADLINE -> eventRepository.findTop200ByStatusOrderByRecruitEndAsc(EventStatus.DRAFT);
+            case CREATED_AT -> eventRepository.findTop200ByStatusOrderByCreatedAtDesc(EventStatus.DRAFT);
+
+            default -> throw new EventException(EventErrorCode.INVALID_EVENT_SORT_TYPE , sortType.name() +"은 ");
+        };
+
+        return eventMapper.toAdminDraftEventRowList(events);
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

1. 관리자 **행사관리 페이지(조회)** 에 필요한 API/Enum/ErrorCode를 추가하고, 행사 마감일(eventEnd) 필수 입력으로 정책을 맞췄습니다.
<img width="350" height="551" alt="image" src="https://github.com/user-attachments/assets/b9aaf9aa-5472-4dc7-87a5-ce792e80f4a4" />

2. 관리자 임시저장(등록 가능한 행사) 조회 API 를 추가했습니다.
<img width="708" height="743" alt="image" src="https://github.com/user-attachments/assets/fab0db45-5c5b-43c9-bd3a-8a9cb3598fb3" />


---

## ✨ 변경 사항
### 1) 관리자 행사 조회 API 추가
- 관리자 행사관리 화면에서 필요한 목록 데이터를 조회할 수 있도록 API를 추가했습니다.
- 정렬/필터/키워드 기반 조회 지원
  - 카테고리 탭(ALL 포함)
  - 종료된 행사 포함 토글(includeEnded)
  - 키워드 검색(title LIKE)
  - 정렬(sort)

### 2) 관리자 페이지용 Enum 추가/확장
- `AdminEventListStatus` : 모집중 / 모집예정 / 모집마감 / 종료 라벨 enum 추가
- `EventCategory` : `ALL` 추가(관리자 탭 "전체" 대응)
- `EventSortType` : 관리자 페이지 정렬 방식 추가

### 3) 관리자 정렬 예외 코드 추가
- 지원하지 않는 정렬 요청 방어를 위해 `INVALID_EVENT_SORT_TYPE` 추가

### 4) 행사 마감일(eventEnd) 필수 입력으로 수정
- 정책상 행사 시작/마감일이 null이 될 수 없도록 입력 조건을 강화했습니다.

---

> 응답에는 상단 통계(summary), 카테고리 탭 카운트(categoryCounts), 리스트(events), 페이지 정보(pageInfoResponse)가 포함됩니다.  
> **등록 가능한 행사 수(creatableCount)는 DRAFT 개수 기준**입니다.

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
