### PR TITLE
[FIX] : 해시태그 기반 이벤트 추천시 상위 6개 해시태그 같이 반환

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/controller/EventController.java
+++ b/src/main/java/com/example/skillup/domain/event/controller/EventController.java
@@ -303,10 +303,9 @@ public class EventController {
     @GetMapping("home/recommended")
     @Operation(summary = "홈 화면에서 해쉬태그 기반으로 이벤트를 추천합니다"
             , description = "홈 화면 이벤트 추천 api")
-    public BaseResponse<List<EventResponse.HomeEventResponse>> getRecommendedEvents(
+    public BaseResponse<EventResponse.EventHashTagResponse> getRecommendedEvents(
             @AuthenticationPrincipal UsersDetails user) {
-        List<EventResponse.HomeEventResponse> events = eventService.getRecommendedEvents(user.getUser().getId(), user);
-        return BaseResponse.success("홈 화면에서 추천 이벤트 조회 성공", events);
+        return BaseResponse.success("홈 화면에서 추천 이벤트 조회 성공", eventService.getRecommendedEvents(user.getUser().getId(), user));
     }
 
     @GetMapping("home/recent")

--- a/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/response/EventResponse.java
@@ -28,6 +28,14 @@ public class EventResponse {
     }
 
     @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class EventHashTagResponse{
+        List<HomeEventResponse> events;
+        List<String> hashTags;
+    }
+
+    @Getter
     @AllArgsConstructor
     @Builder
     public static class EventSelectResponse {

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -254,6 +254,15 @@ public class EventMapper {
                 .toList();
     }
 
+    public EventResponse.EventHashTagResponse toEventHashTagResponse(List<Event> events , Set<Long> bookmarkedEventIds , List<HashTag> hashTags) {
+        List<EventResponse.HomeEventResponse> eventResponses = toHomeEventResponsList(events, bookmarkedEventIds);
+
+        return EventResponse.EventHashTagResponse.builder()
+                .events(eventResponses)
+                .hashTags(hashTags.stream().map(HashTag::getName).toList())
+                .build();
+    }
+
     public List<EventResponse.HomeEventResponse> toCategoryPageEventResponseList(
             List<EventRepositoryImpl.EventWithPopularity> events,
             Set<Long> bookmarkedEventIds

--- a/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
@@ -18,7 +18,7 @@ public interface EventBookmarkRepository extends JpaRepository<EventBookmark, Lo
     @Query("""
         select eb.event
         from EventBookmark eb
-        where eb.user = :user
+        where eb.user = :user and eb.isBookmarked = true
         order by eb.createdAt desc
        """)
     List<Event> findEventsByUserWithLatest(@Param("user") Users user,
@@ -28,7 +28,7 @@ public interface EventBookmarkRepository extends JpaRepository<EventBookmark, Lo
     @Query("""
         select eb.event
         from EventBookmark eb
-        where eb.user = :user
+        where eb.user = :user and eb.isBookmarked = true
         order by eb.event.recruitEnd asc
        """)
     List<Event> findEventsByUserWithDeadLine(@Param("user") Users user,

--- a/src/main/java/com/example/skillup/domain/event/repository/HashTagRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/HashTagRepository.java
@@ -1,10 +1,63 @@
 package com.example.skillup.domain.event.repository;
 
 import com.example.skillup.domain.event.entity.HashTag;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface HashTagRepository extends JpaRepository<HashTag,Long> {
     Optional<HashTag> findByName(String name);
+
+    @Query(value = """
+    SELECT ht.*
+    FROM hash_tag ht
+    JOIN (
+        SELECT activity_tag_weights.hash_tags_id,
+               SUM(activity_tag_weights.weight) AS score
+        FROM (
+
+            SELECT eht2.hash_tags_id AS hash_tags_id,
+                   0.3E0 AS weight
+            FROM event_action ea
+            JOIN event_hash_tags eht2 ON ea.event_id = eht2.event_id
+            WHERE ea.actor_id = :actorId
+              AND ea.created_at >= :since
+              AND ea.action_type = 'VIEW'
+
+            UNION ALL
+
+            SELECT eht3.hash_tags_id AS hash_tags_id,
+                   0.6E0 AS weight
+            FROM event_bookmark eb
+            JOIN event_hash_tags eht3 ON eb.event_id = eht3.event_id
+            WHERE eb.user_id = :userId
+              AND eb.deleted_at IS NULL
+              AND eb.is_bookmarked = true
+              AND eb.updated_at >= :since
+
+            UNION ALL
+
+            SELECT eht4.hash_tags_id AS hash_tags_id,
+                   0.1E0 AS weight
+            FROM event_action ea2
+            JOIN event_hash_tags eht4 ON ea2.event_id = eht4.event_id
+            WHERE ea2.actor_id = :actorId
+              AND ea2.created_at >= :since
+              AND ea2.action_type = 'APPLY'
+        ) AS activity_tag_weights
+        GROUP BY activity_tag_weights.hash_tags_id
+        ORDER BY score DESC
+        LIMIT 6
+    ) top_tags ON ht.id = top_tags.hash_tags_id
+    ORDER BY top_tags.score DESC
+""", nativeQuery = true)
+    List<HashTag> findUserTopHashTagEntitiesTop6(
+            @Param("actorId") String actorId,
+            @Param("userId") Long userId,
+            @Param("since") LocalDateTime since
+    );
 
 }

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -5,8 +5,10 @@ import com.example.skillup.domain.event.dto.request.EventRequest.AdminEventPageR
 import com.example.skillup.domain.event.dto.response.EventResponse;
 import com.example.skillup.domain.event.dto.response.EventResponse.AdminDraftEventResponse;
 import com.example.skillup.domain.event.dto.response.EventResponse.AdminEventPageResponse;
+import com.example.skillup.domain.event.dto.response.EventResponse.EventHashTagResponse;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.entity.EventAction;
+import com.example.skillup.domain.event.entity.HashTag;
 import com.example.skillup.domain.event.enums.ActionType;
 import com.example.skillup.domain.event.enums.ActorType;
 import com.example.skillup.domain.event.enums.EventCategory;
@@ -22,6 +24,7 @@ import com.example.skillup.domain.event.repository.EventRepository;
 import com.example.skillup.domain.event.repository.EventRepository.AdminCategoryCountProjection;
 import com.example.skillup.domain.event.repository.EventRepository.AdminEventSummaryProjection;
 import com.example.skillup.domain.event.repository.EventRepositoryImpl;
+import com.example.skillup.domain.event.repository.HashTagRepository;
 import com.example.skillup.domain.map.provider.GeocodingProvider.GeoPoint;
 import com.example.skillup.domain.map.service.GeocodingService;
 import com.example.skillup.domain.user.entity.Guest;
@@ -73,6 +76,7 @@ public class EventService {
     private final EventBookmarkRepository eventBookmarkRepository;
     private final UserRepository userRepository;
     private final GeocodingService geocodingService;
+    private final HashTagRepository hashTagRepository;
 
     LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
     LocalDateTime now = LocalDateTime.now();
@@ -448,13 +452,18 @@ public class EventService {
 
     @Transactional(readOnly = true)
     @HandleDataAccessException
-    public List<EventResponse.HomeEventResponse> getRecommendedEvents(Long actorId, UsersDetails user) {
+    public EventHashTagResponse getRecommendedEvents(Long actorId, UsersDetails user) {
         List<Event> events = eventRepository.findRecommendedEventForHome(actorId.toString(), actorId, since);
 
         List<Long> eventIds = events.stream().map(Event::getId).toList();
         Set<Long> bookmarkedEventIds = getBookmarkedEventId(user, eventIds);
+        List<HashTag> Top6HashTags = hashTagRepository.findUserTopHashTagEntitiesTop6(actorId.toString() , actorId , since);
 
-        return eventMapper.toHomeEventResponsList(events, bookmarkedEventIds);
+        //현재는 중복으로 조회를 하는데 해당 중복 구간을 나누기가 어려워서 납뒀습니다.
+        //중복으로 하지 않으려면 이벤트 정렬 순서만 없으면 상관없지만 tag_score 점수를 활용해서 이벤트도 점수에따라 순차적으로 내리려면 이렇게 하는 현재로선 방법이 최선인 거 같아요
+        //추후에 더 좋은 방법 있으면 리팩토링 해보는것도 좋을 거 같아요
+
+        return eventMapper.toEventHashTagResponse(events , bookmarkedEventIds , Top6HashTags);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/example/skillup/domain/event/service/EventBookmarkServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/service/EventBookmarkServiceTest.java
@@ -81,7 +81,7 @@ public class EventBookmarkServiceTest {
                 .thumbnailUrl("https://example.com/thumb/backend.jpg")
                 .applyClicks(120L)
                 .viewsCount(0L)
-                .likesCount(0L)
+                .bookmarkedCount(0L)
                 .applyLink("https://example.com/apply/backend")
                 .locationText("서울 강남")
                 .locationLink("https://maps.example.com/abc")

--- a/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
@@ -655,16 +655,23 @@ public class EventServiceTest {
         eventRepository.saveAll(List.of(event1, event2, event3));
 
         EventAction action = EventAction.builder().event(event2).actorType(ActorType.USER).actionType(ActionType.VIEW)
-                .actorId("3L").build();
+                .actorId("3").build();
 
         eventActionRepository.save(action);
 
-        List<EventResponse.HomeEventResponse> events = eventService.getRecommendedEvents(3L , null);
-        assertThat(events).isNotEmpty();
-        assertThat(events.size()).isEqualTo(2);
-        for (EventResponse.HomeEventResponse event : events) {
-            System.out.println(event.getTitle());
-        }
+        EventResponse.EventHashTagResponse response = eventService.getRecommendedEvents(3L , null);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getEvents()).isNotNull();
+        assertThat(response.getHashTags()).isNotNull();
+
+        assertThat(response.getEvents()).isNotEmpty();
+
+        assertThat(response.getHashTags()).isNotEmpty();
+        assertThat(response.getHashTags().size()).isEqualTo(3);
+        assertThat(response.getEvents())
+                .extracting(EventResponse.HomeEventResponse::getTitle)
+                .contains("테스트 이벤트2");
 
     }
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

해시태그 기반 이벤트 추천시 상위 6개 해시태그는 반환하지않아서 해당 부분 추가했습니다.
  - Test 부분도 같이 수정했습니다.

또한 user 의 bookmark 조회시 true false 값 확인하지 않는 문제가 있어서 수정했습니다.

 **현재 상위 6개 해시태그 조회 및 상위 6개 해시태그의 점수를 기반으로 이벤트를 조회하는데 같은 계산 쿼리가 있어요
해당 부분 나중에 추가적인 작업이 필요할 거 같아요**

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x]  버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
