### PR TITLE
[FEAT] : 로그인 사용자 검색기록 저장/삭제/조회 api 추가

### DIFF
--- a/src/main/java/com/example/skillup/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/skillup/domain/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.example.skillup.domain.user.controller;
 
 
-
 import com.example.skillup.domain.user.dto.request.UserRequest;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.UsersDetails;
@@ -10,12 +9,21 @@ import com.example.skillup.global.auth.service.AuthService;
 import com.example.skillup.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -26,10 +34,9 @@ public class UserController {
     private final AuthService authService;
 
     @GetMapping()
-    public BaseResponse<UserResponse.UserProfileResponse> getUsers(@AuthenticationPrincipal UsersDetails user)
-    {
+    public BaseResponse<UserResponse.UserProfileResponse> getUsers(@AuthenticationPrincipal UsersDetails user) {
         return BaseResponse.success("유저 조회 성공"
-        ,userService.getUsers(user.getUser()));
+                , userService.getUsers(user.getUser()));
 
     }
 
@@ -65,9 +72,8 @@ public class UserController {
     @GetMapping("/my-page/profile/interest")
     @Operation(summary = "유저 프로필상 직무별 관심사를 불러옵니다(관심사의 유지 보수 및 정합성 관리를 위하여 DB 레벨에서 관리) "
             , description = "유저 프로필상 직무별 관심사를 가져오는 API ")
-    public BaseResponse<List<UserResponse.InterestResponse>> getInterestByRole(@RequestParam String roleName)
-    {
-        return BaseResponse.success("직무별 관심사 조회 성공",userService.getInterestByRole(roleName));
+    public BaseResponse<List<UserResponse.InterestResponse>> getInterestByRole(@RequestParam String roleName) {
+        return BaseResponse.success("직무별 관심사 조회 성공", userService.getInterestByRole(roleName));
     }
 
     @PutMapping(value = "/my-page/profile/update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -88,9 +94,9 @@ public class UserController {
     }
 
     @GetMapping("my-page/with-draw/category")
-    @Operation(description="사이트에서 제공하는 정형화된 탈퇴 사유 목록을 조회합니다.")
+    @Operation(description = "사이트에서 제공하는 정형화된 탈퇴 사유 목록을 조회합니다.")
     public BaseResponse<List<UserResponse.WithDrawReasonCategoryResponse>> getWithDrawReasonCategory() {
-        return BaseResponse.success("정형화된 탈퇴 사유 조회 성공",userService.getWithDrawReasonCategory());
+        return BaseResponse.success("정형화된 탈퇴 사유 조회 성공", userService.getWithDrawReasonCategory());
     }
 
     @DeleteMapping("my-page/with-draw")
@@ -98,8 +104,8 @@ public class UserController {
     public BaseResponse<Boolean> deleteUser(
             @RequestBody UserRequest.UserWithdrawRequest request,
             @AuthenticationPrincipal UsersDetails userDetails) {
-        userService.deleteUser(request,userDetails.getUser());
-        return BaseResponse.success("회원 탈퇴 성공",true);
+        userService.deleteUser(request, userDetails.getUser());
+        return BaseResponse.success("회원 탈퇴 성공", true);
     }
 
     @PutMapping("/oauth/signup")
@@ -110,8 +116,43 @@ public class UserController {
             @AuthenticationPrincipal UsersDetails user
     ) {
         userService.completeSignup(user.getUser(), request);
-        return BaseResponse.success("추가 정보 입력 성공",null);
+        return BaseResponse.success("추가 정보 입력 성공", null);
     }
 
+    @GetMapping("/search/recent")
+    @Operation(summary = "검색 기록 조회 API", description = "최근 검색 기록 6개를 조회하는 API 입니다.")
+    public BaseResponse<UserResponse.RecentSearchListResponse> getRecent(
+            @AuthenticationPrincipal(errorOnInvalidType = true) UsersDetails user
+    ) {
+        return BaseResponse.success("최근 검색 기록 조회 성공", userService.getRecentSearches(user.getUser().getId()));
+    }
 
+    @PostMapping("/search/recent")
+    @Operation(summary = "검색 기록 저장 API")
+    public BaseResponse<Void> saveRecentKeyword(
+            @AuthenticationPrincipal(errorOnInvalidType = true) UsersDetails user,
+            @Valid @RequestBody UserRequest.SaveRecentSearchRequest request
+    ) {
+        userService.saveRecentSearchKeyword(user.getUser().getId(), request.getKeyword());
+        return BaseResponse.success("검색 기록 저장에 성공했습니다.", null);
+    }
+
+    @DeleteMapping("/search/recent/{recentId}")
+    @Operation(summary = "단일 검색 기록 삭제 API")
+    public BaseResponse<Void> deleteRecentKeywordOne(
+            @AuthenticationPrincipal(errorOnInvalidType = true) UsersDetails user,
+            @PathVariable Long recentId
+    ) {
+        userService.deleteRecentSearchKeyword(user.getUser().getId(), recentId);
+        return BaseResponse.success("검색 기록 삭제 성공", null);
+    }
+
+    @DeleteMapping("/search/recent/all")
+    @Operation(summary = "전체 검색 기록 삭제 API")
+    public BaseResponse<Void> deleteRecentKeywordAll(
+            @AuthenticationPrincipal(errorOnInvalidType = true) UsersDetails user
+    ) {
+        userService.deleteAll(user.getUser().getId());
+        return BaseResponse.success("검색 기록 전체 삭제 성공" , null);
+    }
 }

--- a/src/main/java/com/example/skillup/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/request/UserRequest.java
@@ -1,15 +1,14 @@
 package com.example.skillup.domain.user.dto.request;
 
-import java.util.List;
-
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-public class UserRequest
-{
+public class UserRequest {
     @Getter
     @AllArgsConstructor
     @Builder
@@ -36,5 +35,15 @@ public class UserRequest
     public static class UserWithdrawRequest {
         @Size(max = 500, message = "탈퇴 사유는 최대 500자까지 입력할 수 있습니다.")
         private String detail;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class SaveRecentSearchRequest {
+
+        @NotBlank(message = "keyword는 공백일 수 없습니다.")
+        @Size(max = 200, message = "keyword는 200자를 초과할 수 없습니다.")
+        private String keyword;
     }
 }

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -1,18 +1,11 @@
 package com.example.skillup.domain.user.dto.response;
 
 import com.example.skillup.domain.event.dto.response.EventResponse;
-import com.example.skillup.domain.event.entity.TargetRole;
-import com.example.skillup.domain.oauth.Entity.SocialLoginType;
-import com.example.skillup.domain.user.entity.Users;
-import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.common.CommonResponse;
-import jakarta.persistence.Column;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 public class UserResponse {
 
@@ -116,5 +109,20 @@ public class UserResponse {
     public static class WithDrawReasonCategoryResponse
     {
         private String description;
+    }
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class RecentSearchItem {
+        private Long id;
+        private String keyword;
+    }
+
+    @Getter
+    @Builder
+    public static class RecentSearchListResponse {
+        private List<RecentSearchItem> items;
     }
 }

--- a/src/main/java/com/example/skillup/domain/user/entity/RecentSearch.java
+++ b/src/main/java/com/example/skillup/domain/user/entity/RecentSearch.java
@@ -1,0 +1,45 @@
+package com.example.skillup.domain.user.entity;
+
+import com.example.skillup.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "recent_search",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_recent_search_user_keyword", columnNames = {"user_id", "keyword"})
+        },
+        indexes = {
+                @Index(name = "idx_recent_search_user_updated_at", columnList = "user_id, updated_at DESC"),
+                @Index(name = "idx_recent_search_user_keyword", columnList = "user_id, keyword")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class RecentSearch extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "keyword", nullable = false, length = 200)
+    private String keyword;
+
+}

--- a/src/main/java/com/example/skillup/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/skillup/domain/user/exception/UserErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ResultCode
 {
-    USER_ENTITY_NOT_FOUND("USER_ENTITY_NOT_FOUND","유저가 존재하지 않습니다", HttpStatus.NOT_FOUND);
+    USER_ENTITY_NOT_FOUND("USER_ENTITY_NOT_FOUND","유저가 존재하지 않습니다", HttpStatus.NOT_FOUND),
+    RECENT_SEARCH_ENTITY_NOT_FOUND("RECENT_SEARCH_ENTITY_NOT_FOUND","검색기록이 존재하지 않습니다", HttpStatus.NOT_FOUND),
+    RECENT_SEARCH_FORBIDDEN("RECENT_SEARCH_FORBIDDEN", "해당 검색기록에 대한 권한이 없습니다", HttpStatus.FORBIDDEN),;
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -7,16 +7,16 @@ import com.example.skillup.domain.oauth.dto.OauthRequest;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Inquiry;
 import com.example.skillup.domain.user.entity.Interest;
+import com.example.skillup.domain.user.entity.RecentSearch;
 import com.example.skillup.domain.user.entity.Users;
 import com.example.skillup.domain.user.entity.WithdrawReasonCategory;
 import com.example.skillup.domain.user.enums.UserStatus;
 import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.common.CommonResponse;
-import org.springframework.stereotype.Component;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
 
 @Component
 public class UserMapper {
@@ -145,6 +145,17 @@ public class UserMapper {
                 .viewCount(viewCount)
                 .saveCount(saveCount)
                 .applyCount(applyCount)
+                .build();
+    }
+
+    public UserResponse.RecentSearchListResponse toRecentSearchListResponse(List<RecentSearch> recentSearches) {
+        return UserResponse.RecentSearchListResponse.builder()
+                .items(recentSearches.stream()
+                        .map(r -> UserResponse.RecentSearchItem.builder()
+                                .id(r.getId())
+                                .keyword(r.getKeyword())
+                                .build())
+                        .toList())
                 .build();
     }
 

--- a/src/main/java/com/example/skillup/domain/user/repository/RecentSearchRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/RecentSearchRepository.java
@@ -1,0 +1,47 @@
+package com.example.skillup.domain.user.repository;
+
+import com.example.skillup.domain.event.exception.EventException;
+import com.example.skillup.domain.user.entity.RecentSearch;
+import com.example.skillup.domain.user.exception.UserErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RecentSearchRepository extends JpaRepository<RecentSearch, Long> {
+
+    default RecentSearch getRecentSearch(Long recentSearchId) {
+        return findById(recentSearchId).orElseThrow(
+                () -> new EventException(UserErrorCode.RECENT_SEARCH_ENTITY_NOT_FOUND,
+                        "RecentSearchId 가 " + recentSearchId + "인"));
+    }
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+                DELETE FROM RecentSearch r
+                WHERE r.userId = :userId
+                  AND r.updatedAt < :since
+            """)
+    void deleteExpiredByUserId(Long userId, LocalDateTime since);
+
+    Optional<RecentSearch> findByUserIdAndKeyword(Long userId, String keyword);
+
+    @Query("""
+                SELECT r
+                FROM RecentSearch r
+                WHERE r.userId = :userId
+                  AND r.updatedAt >= :since
+                ORDER BY r.updatedAt DESC
+            """)
+    List<RecentSearch> findTopByUserIdSinceOrderByUpdatedAtDesc(Long userId, LocalDateTime since, Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+                DELETE FROM RecentSearch r
+                WHERE r.userId = :userId
+            """)
+    int deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/example/skillup/domain/user/service/UserService.java
+++ b/src/main/java/com/example/skillup/domain/user/service/UserService.java
@@ -12,19 +12,24 @@ import com.example.skillup.domain.event.repository.TargetRoleRepository;
 import com.example.skillup.domain.user.dto.request.UserRequest;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Interest;
+import com.example.skillup.domain.user.entity.RecentSearch;
 import com.example.skillup.domain.user.entity.Users;
+import com.example.skillup.domain.user.exception.UserErrorCode;
+import com.example.skillup.domain.user.exception.UserException;
 import com.example.skillup.domain.user.mappers.UserMapper;
 import com.example.skillup.domain.user.repository.InquiryRepository;
 import com.example.skillup.domain.user.repository.InterestRepository;
+import com.example.skillup.domain.user.repository.RecentSearchRepository;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.domain.user.repository.WithdrawReasonCategoryRepository;
 import com.example.skillup.global.aop.ConvertNotFound;
 import com.example.skillup.global.common.CommonResponse;
 import com.example.skillup.global.service.NotFoundGuardService;
 import com.example.skillup.global.service.S3Service;
-
-import java.util.*;
-
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -36,6 +41,9 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
+
+    private static final int RETENTION_DAYS = 30;
+
     final private UserMapper userMapper;
     final private EventBookmarkRepository eventBookmarkRepository;
     final private InterestRepository interestRepository;
@@ -46,6 +54,7 @@ public class UserService {
     private final WithdrawReasonCategoryRepository withDrawReasonCategoryRepository;
     private final S3Service s3Service;
     private final NotFoundGuardService notFoundGuardService;
+    private final RecentSearchRepository recentSearchRepository;
 
     public UserResponse.MyPageHomeResponse getMyPageHome(Users user) {
         return userMapper.toMyPageHomeResponse(user);
@@ -141,5 +150,62 @@ public class UserService {
         TargetRole role = notFoundGuardService.getRole(request.getRole());
         Set<Interest> interests = notFoundGuardService.getInterestFindByNameIn(request.getInterests());
         user.update(null,role,interests,null);
+    }
+
+
+
+    @Transactional
+    public UserResponse.RecentSearchListResponse getRecentSearches(Long userId) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime since = now.minusDays(RETENTION_DAYS);
+
+        recentSearchRepository.deleteExpiredByUserId(userId , since);
+
+        List<RecentSearch> recentKeywords =
+                recentSearchRepository.findTopByUserIdSinceOrderByUpdatedAtDesc(
+                        userId, since, PageRequest.of(0, 6)
+                );
+
+        return userMapper.toRecentSearchListResponse(recentKeywords);
+    }
+
+
+
+    @Transactional
+    public void saveRecentSearchKeyword(Long userId, String keyword) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime since = now.minusDays(RETENTION_DAYS);
+
+        recentSearchRepository.deleteExpiredByUserId(userId , since); // 만료된 데이터 정리
+
+        String trimmedKeyword = keyword.trim();
+
+        RecentSearch recent = recentSearchRepository.findByUserIdAndKeyword(userId, trimmedKeyword)
+                .map(existing ->{
+                    existing.setUpdatedAt();
+                    return existing;
+                })
+                .orElseGet(()-> RecentSearch.builder()
+                        .userId(userId)
+                        .keyword(trimmedKeyword)
+                        .build());
+
+        recentSearchRepository.save(recent);
+    }
+
+    @Transactional
+    public void deleteRecentSearchKeyword(Long userId, Long recentId) {
+        RecentSearch recentSearch = recentSearchRepository.getRecentSearch(recentId);
+
+        if (!recentSearch.getUserId().equals(userId)) {
+            throw new UserException(UserErrorCode.RECENT_SEARCH_FORBIDDEN);
+        }
+
+        recentSearchRepository.delete(recentSearch);
+    }
+
+    @Transactional
+    public void deleteAll(Long userId) {
+        recentSearchRepository.deleteAllByUserId(userId);
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

최근 검색어(검색 기록) **저장/조회/삭제 API**를 구현했습니다.  
로그인 사용자 기준으로 서버(DB)에 최근 검색어를 관리하며, 중복 키워드 처리정책을 적용했습니다.

---

## 🔥 주요 변경 사항
### 1) 최근 검색어 저장 API 추가
- 사용자가 검색할 때 키워드를 저장합니다.
- **동일 키워드가 이미 존재하면 신규 생성하지 않고 최신화(update)** 처리하여 상단으로 올라오게 했습니다.
- **30일 이전 데이터 정리 로직** 포함.

### 2) 최근 검색어 조회 API 추가
- 조회시에도 30일 이전 데이터 정리 로직 포함하게끔 구현했습니다.
- 최대 6개까지 불러오도록 구현했습니다.

### 3) 최근 검색어 삭제 API 추가
- **개별 삭제**: 특정 recent search id 삭제
  - 본인 소유 데이터가 아니면 **403(Forbidden)** 처리 (`RECENT_SEARCH_FORBIDDEN`)
  - 존재하지 않으면 **404(Not Found)** 처리 (`RECENT_SEARCH_ENTITY_NOT_FOUND`)
- **전체 삭제**: 해당 유저의 최근 검색어 전체 삭제
  - `userId` 조건으로만 삭제되어 별도 소유자 검증 불필요(인증된 userId 전제)

### 4) 엔티티/DB 제약 추가
- `recent_search` 테이블 신규 생성
- `(user_id, keyword)` **Unique 제약** 추가로 동일 키워드 중복 생성 방지
- 조회 성능을 위한 인덱스 추가:
  - `(user_id, updated_at desc)` : 최신순 6개 조회 최적화
  - `(user_id, keyword)` : 중복 키워드 조회 최적화

### 5) 예외 코드 추가
- `UserErrorCode`에 최근 검색어 관련 에러코드 추가/정리
  - `RECENT_SEARCH_ENTITY_NOT_FOUND` (404)
  - `RECENT_SEARCH_FORBIDDEN` (403)

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
