### PR TITLE
[HOTFIX] : 유저 북마크 개수 반환 api 수정

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
@@ -5,6 +5,7 @@ import com.example.skillup.domain.event.entity.EventBookmark;
 import com.example.skillup.domain.user.entity.Users;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,7 +22,7 @@ public interface EventBookmarkRepository extends JpaRepository<EventBookmark, Lo
         where eb.user = :user and eb.isBookmarked = true
         order by eb.createdAt desc
        """)
-    List<Event> findEventsByUserWithLatest(@Param("user") Users user,
+    Page<Event> findEventsByUserWithLatest(@Param("user") Users user,
                                            Pageable pageable);
 
 
@@ -31,7 +32,7 @@ public interface EventBookmarkRepository extends JpaRepository<EventBookmark, Lo
         where eb.user = :user and eb.isBookmarked = true
         order by eb.event.recruitEnd asc
        """)
-    List<Event> findEventsByUserWithDeadLine(@Param("user") Users user,
+    Page<Event> findEventsByUserWithDeadLine(@Param("user") Users user,
                               Pageable pageable);
 
 

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -70,10 +70,10 @@ public class UserMapper {
     }
 
     public UserResponse.MyPageBookMarkResponse toMyPageBookMarkResponse(Users user, List<EventResponse.HomeEventResponse> recruitingEvents,
-                                                                        List<EventResponse.HomeEventResponse> closedEvents, CommonResponse.PageInfoResponse pageInfoResponse)
+                                                                        List<EventResponse.HomeEventResponse> closedEvents, CommonResponse.PageInfoResponse pageInfoResponse, long totalElements)
     {
         return UserResponse.MyPageBookMarkResponse.builder()
-                .bookmarkCount(recruitingEvents.size()+closedEvents.size())
+                .bookmarkCount((int) totalElements)
                 .recruitingEvents(recruitingEvents)
                 .closedEvents(closedEvents)
                 .email(user.getEmail())

--- a/src/main/java/com/example/skillup/domain/user/service/UserService.java
+++ b/src/main/java/com/example/skillup/domain/user/service/UserService.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -62,8 +63,8 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserResponse.MyPageBookMarkResponse getMyPageBookMark(Users user, String sort, int page) {
-        List<Event> eventBookmarks = new ArrayList<>();
         Pageable pageable = PageRequest.of(page, 9);
+        Page<Event> eventBookmarks = Page.empty(pageable);
 
         //user를 영속성 컨텍스트로 만들기 위해서
         user = notFoundGuardService.getUsersNative(user.getId());
@@ -72,15 +73,15 @@ public class UserService {
             case "latest" -> eventBookmarks = eventBookmarkRepository.findEventsByUserWithLatest(user, pageable);
             case "deadline" -> eventBookmarks = eventBookmarkRepository.findEventsByUserWithDeadLine(user, pageable);
         }
-        List<EventResponse.HomeEventResponse> eventBookmarksDto = eventBookmarks.stream()
+        List<EventResponse.HomeEventResponse> eventBookmarksDto = eventBookmarks.getContent().stream()
                 .map(event -> eventMapper.toFeaturedEvent(event, true, event.isRecommendedManual(), event.isAd(), null))
                 .toList();
 
         CommonResponse.PageInfoResponse pageInfoResponse = CommonResponse.PageInfoResponse
                 .builder()
                 .currentPage(page + 1)
-                .pageSize(pageable.getPageSize())
-                .totalPages((int) Math.ceil((double) eventBookmarksDto.size() / (pageable.getPageSize())))
+                .pageSize(eventBookmarks.getSize())
+                .totalPages(eventBookmarks.getTotalPages())
                 .build();
 
         List<EventResponse.HomeEventResponse> recruitingEvents = new ArrayList<>();
@@ -93,7 +94,7 @@ public class UserService {
                 recruitingEvents.add(event);
             }
         }
-        return userMapper.toMyPageBookMarkResponse(user, recruitingEvents, closedEvents, pageInfoResponse);
+        return userMapper.toMyPageBookMarkResponse(user, recruitingEvents, closedEvents, pageInfoResponse ,eventBookmarks.getTotalElements() );
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

유저 북마크 리스트 반환 API 의 경우 전체 개수 및 총 페이지 관련 값이 잘못 설정되어있어서 repo 에서 List<Event> 가 아닌 Page<Event> 로 수정해서 pageInfoResponse 를 수정했습니다.

## PR 유형
어떤 변경 사항이 있나요?
- [] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
