### PR TITLE
[FIX] 다른 오어스 로그인 및 재가입 처리를 위한 Oauth 로그인 응답 구조 변경 및 재 로그인 API 추가

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/entity/Event.java
+++ b/src/main/java/com/example/skillup/domain/event/entity/Event.java
@@ -41,7 +41,7 @@ public class Event extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(unique = true)
     private String title;
 
     @Column(length = 512)

--- a/src/main/java/com/example/skillup/domain/oauth/dto/OauthResponse.java
+++ b/src/main/java/com/example/skillup/domain/oauth/dto/OauthResponse.java
@@ -12,5 +12,25 @@ public class OauthResponse {
     public static class OAuthLoginResponse {
         private String accessToken;
         private String userLoginStatus;
+        private OtherOauthUserInfo otherOauthUserInfo;
+        private WithdrawPendingUserInfo withdrawPendingUserInfo;
+    }
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class OtherOauthUserInfo {
+        private String socialLoginType;
+        private String email;
+        private String socialId;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class WithdrawPendingUserInfo {
+        private String socialLoginType;
+        private String socialId;
     }
 }

--- a/src/main/java/com/example/skillup/domain/oauth/mapper/OauthMapper.java
+++ b/src/main/java/com/example/skillup/domain/oauth/mapper/OauthMapper.java
@@ -13,4 +13,41 @@ public class OauthMapper
     ){
         return OauthResponse.OAuthLoginResponse.builder().accessToken(accessToken).userLoginStatus(userLoginStatus).build();
     }
+
+    public OauthResponse.OAuthLoginResponse toOtherOauthUserResponse(
+            String socialLoginType,
+            String email,
+            String socialId,
+            String userLoginStatus
+
+    ) {
+        OauthResponse.OtherOauthUserInfo info =
+                OauthResponse.OtherOauthUserInfo.builder()
+                        .socialLoginType(socialLoginType)
+                        .email(email)
+                        .socialId(socialId)
+                        .build();
+
+        return OauthResponse.OAuthLoginResponse.builder()
+                .userLoginStatus(userLoginStatus)
+                .otherOauthUserInfo(info)
+                .build();
+    }
+
+    public OauthResponse.OAuthLoginResponse toWithdrawPendingUserResponse(
+            String socialLoginType,
+            String socialId,
+            String userLoginStatus
+    ) {
+        OauthResponse.WithdrawPendingUserInfo info =
+                OauthResponse.WithdrawPendingUserInfo.builder()
+                        .socialLoginType(socialLoginType)
+                        .socialId(socialId)
+                        .build();
+
+        return OauthResponse.OAuthLoginResponse.builder()
+                .userLoginStatus(userLoginStatus)
+                .withdrawPendingUserInfo(info)
+                .build();
+    }
 }

--- a/src/main/java/com/example/skillup/domain/oauth/service/OauthService.java
+++ b/src/main/java/com/example/skillup/domain/oauth/service/OauthService.java
@@ -65,14 +65,28 @@ public class OauthService {
 
         if (existingUser.isPresent()) {
             user = existingUser.get();
+
+            if(user.getStatus().equals(UserStatus.WITHDRAWN))
+            {
+                status=UserLoginStatus.WITHDRAW_PENDING_USER;
+
+                return oauthMapper.toWithdrawPendingUserResponse
+                        (user.getSocialLoginType().name(),user.getSocialId(),status.name());
+            }
+
             user.updateLastLoginAt(LocalDateTime.now());
             status=UserLoginStatus.EXISTING_USER;
-            if(!user.getSocialLoginType().equals(socialLoginType))
-                status=UserLoginStatus.OTHER_OAUTH_USER;
-            if(user.getStatus().equals(UserStatus.WITHDRAWN))
-                status=UserLoginStatus.WITHDRAW_PENDING_USER;
         }
         else {
+            Users equalUsers=userRepository.findByEmail(oauthInfoRequest.email()).orElse(null);
+            if(equalUsers!=null)
+            {
+                status = UserLoginStatus.OTHER_OAUTH_USER;
+                return oauthMapper.toOtherOauthUserResponse
+                        (equalUsers.getSocialLoginType().name(),equalUsers.getEmail(),
+                                equalUsers.getSocialId(),status.name());
+
+            }
             user = userMapper.fromOauthInfo(
                     oauthInfoRequest,
                     targetRoleRepository.findByName("기획자").orElseThrow()
@@ -85,7 +99,7 @@ public class OauthService {
         TokenResponse tokenResponse =authService.login(user.getEmail(),"users");
 
 
-        return oauthMapper.toOauthLoginResponse(tokenResponse.accessToken(),status.toString());
+        return oauthMapper.toOauthLoginResponse(tokenResponse.accessToken(),status.name());
     }
 
 }

--- a/src/main/java/com/example/skillup/domain/oauth/service/OauthService.java
+++ b/src/main/java/com/example/skillup/domain/oauth/service/OauthService.java
@@ -58,7 +58,8 @@ public class OauthService {
 
         OauthRequest oauthInfoRequest= client.parse(userInfo,accessToken);
 
-        Optional<Users> existingUser = userRepository.findBySocialId(oauthInfoRequest.socialId());
+        Optional<Users> existingUser = userRepository.findBySocialLoginTypeAndSocialId
+                (socialLoginType, oauthInfoRequest.socialId());
 
         Users user;
         UserLoginStatus status;

--- a/src/main/java/com/example/skillup/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/skillup/domain/user/controller/UserController.java
@@ -155,4 +155,15 @@ public class UserController {
         userService.deleteAll(user.getUser().getId());
         return BaseResponse.success("검색 기록 전체 삭제 성공" , null);
     }
+
+    @PostMapping("/continue-login")
+    @Operation(summary = "탈퇴 대기 사용자 재로그인 및 다른 소셜 계정 로그인 처리 API",
+            description = "탈퇴 대기 사용자 재로그인과 다른 소셜 계정 로그인 처리를 이 API가 다 처리하므로 만약 다른 소셜 계정 로그인이 탈퇴" +
+                    "대기 상태라면 재가입으로 처리합니다")
+    public BaseResponse<UserResponse.ContinueLoginResponse> continueLogin(@RequestBody UserRequest.ContinueLoginRequest request) {
+        return BaseResponse.success("재 로그인 성공" , userService.continueLogin(request));
+    }
+
+
+
 }

--- a/src/main/java/com/example/skillup/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/request/UserRequest.java
@@ -46,4 +46,12 @@ public class UserRequest {
         @Size(max = 200, message = "keyword는 200자를 초과할 수 없습니다.")
         private String keyword;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ContinueLoginRequest {
+        private String socialLoginType;
+        private String socialId;
+    }
 }

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -125,4 +125,11 @@ public class UserResponse {
     public static class RecentSearchListResponse {
         private List<RecentSearchItem> items;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ContinueLoginResponse {
+        private String accessToken;
+    }
 }

--- a/src/main/java/com/example/skillup/domain/user/entity/Users.java
+++ b/src/main/java/com/example/skillup/domain/user/entity/Users.java
@@ -114,5 +114,10 @@ public class Users extends BaseEntity
         this.lastLoginAt = lastLoginAt;
     }
 
+    public void rejoin()
+    {
+        this.status= UserStatus.ACTIVE;
+    }
+
 
 }

--- a/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/skillup/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.example.skillup.domain.user.repository;
 
+import com.example.skillup.domain.oauth.Entity.SocialLoginType;
 import com.example.skillup.domain.user.entity.Users;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,7 +15,10 @@ public interface UserRepository extends JpaRepository<Users, Long> {
 
     Optional<Users> findByEmail(String email);
 
-    Optional<Users> findBySocialId(String socialId);
+    Optional<Users> findBySocialLoginTypeAndSocialId(
+            SocialLoginType socialLoginType,
+            String socialId
+    );
 
     @Query(
             value = """

--- a/src/main/java/com/example/skillup/domain/user/service/UserService.java
+++ b/src/main/java/com/example/skillup/domain/user/service/UserService.java
@@ -33,7 +33,6 @@ import com.example.skillup.global.service.S3Service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -100,7 +99,8 @@ public class UserService {
                 recruitingEvents.add(event);
             }
         }
-        return userMapper.toMyPageBookMarkResponse(user, recruitingEvents, closedEvents, pageInfoResponse ,eventBookmarks.getTotalElements() );
+        return userMapper.toMyPageBookMarkResponse(user, recruitingEvents, closedEvents, pageInfoResponse,
+                eventBookmarks.getTotalElements());
     }
 
     @Transactional(readOnly = true)
@@ -111,9 +111,9 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public List<UserResponse.WithDrawReasonCategoryResponse> getWithDrawReasonCategory()
-    {
-        return withDrawReasonCategoryRepository.findAll().stream().map(userMapper::toWithDrawReasonCategoryResponse).toList();
+    public List<UserResponse.WithDrawReasonCategoryResponse> getWithDrawReasonCategory() {
+        return withDrawReasonCategoryRepository.findAll().stream().map(userMapper::toWithDrawReasonCategoryResponse)
+                .toList();
     }
 
     @ConvertNotFound(
@@ -127,9 +127,10 @@ public class UserService {
         user = notFoundGuardService.getUsersNative(user.getId());
         TargetRole role = notFoundGuardService.getRole(request.getRole());
         Set<Interest> interests = notFoundGuardService.getInterestFindByNameIn(request.getInterests());
-        String userProfileImageUrl=null;
-        if(profileImage!=null && !profileImage.isEmpty())
+        String userProfileImageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
             userProfileImageUrl = s3Service.uploadFile(profileImage, "user/profile");
+        }
         user.update(request, role, interests, userProfileImageUrl);
         return userMapper.toUserProfileResponse(user);
     }
@@ -145,20 +146,18 @@ public class UserService {
     }
 
     @Transactional
-    public void deleteUser(UserRequest.UserWithdrawRequest request,Users user) {
+    public void deleteUser(UserRequest.UserWithdrawRequest request, Users user) {
         user = notFoundGuardService.getUsersNative(user.getId());
         user.withdraw(request.getDetail());
     }
 
     @Transactional
-    public void completeSignup(Users user, UserRequest.UserOAuthSignupRequest request)
-    {
+    public void completeSignup(Users user, UserRequest.UserOAuthSignupRequest request) {
         user = notFoundGuardService.getUsersNative(user.getId());
         TargetRole role = notFoundGuardService.getRole(request.getRole());
         Set<Interest> interests = notFoundGuardService.getInterestFindByNameIn(request.getInterests());
-        user.update(null,role,interests,null);
+        user.update(null, role, interests, null);
     }
-
 
 
     @Transactional
@@ -166,7 +165,7 @@ public class UserService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime since = now.minusDays(RETENTION_DAYS);
 
-        recentSearchRepository.deleteExpiredByUserId(userId , since);
+        recentSearchRepository.deleteExpiredByUserId(userId, since);
 
         List<RecentSearch> recentKeywords =
                 recentSearchRepository.findTopByUserIdSinceOrderByUpdatedAtDesc(
@@ -177,22 +176,21 @@ public class UserService {
     }
 
 
-
     @Transactional
     public void saveRecentSearchKeyword(Long userId, String keyword) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime since = now.minusDays(RETENTION_DAYS);
 
-        recentSearchRepository.deleteExpiredByUserId(userId , since); // 만료된 데이터 정리
+        recentSearchRepository.deleteExpiredByUserId(userId, since); // 만료된 데이터 정리
 
         String trimmedKeyword = keyword.trim();
 
         RecentSearch recent = recentSearchRepository.findByUserIdAndKeyword(userId, trimmedKeyword)
-                .map(existing ->{
+                .map(existing -> {
                     existing.setUpdatedAt();
                     return existing;
                 })
-                .orElseGet(()-> RecentSearch.builder()
+                .orElseGet(() -> RecentSearch.builder()
                         .userId(userId)
                         .keyword(trimmedKeyword)
                         .build());
@@ -217,15 +215,16 @@ public class UserService {
     }
 
     @Transactional
-    public UserResponse.ContinueLoginResponse continueLogin(UserRequest.ContinueLoginRequest request)
-    {
-        Users user=userRepository.findBySocialLoginTypeAndSocialId
-                (SocialLoginType.valueOf(request.getSocialLoginType()),request.getSocialId()).orElse(null);
+    public UserResponse.ContinueLoginResponse continueLogin(UserRequest.ContinueLoginRequest request) {
+        Users user = userRepository.findBySocialLoginTypeAndSocialId
+                        (SocialLoginType.valueOf(request.getSocialLoginType()), request.getSocialId())
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_ENTITY_NOT_FOUND, "해당 사용자가 존재하지 않습니다."));
 
-        if(user.getStatus()== UserStatus.WITHDRAWN)
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
             user.rejoin();
+        }
 
-        TokenResponse tokenResponse =authService.login(user.getEmail(),"users");
+        TokenResponse tokenResponse = authService.login(user.getEmail(), "users");
 
         return UserResponse.ContinueLoginResponse.builder().accessToken(tokenResponse.accessToken()).build();
     }

--- a/src/main/java/com/example/skillup/domain/user/service/UserService.java
+++ b/src/main/java/com/example/skillup/domain/user/service/UserService.java
@@ -9,11 +9,13 @@ import com.example.skillup.domain.event.exception.TargetRoleErrorCode;
 import com.example.skillup.domain.event.mapper.EventMapper;
 import com.example.skillup.domain.event.repository.EventBookmarkRepository;
 import com.example.skillup.domain.event.repository.TargetRoleRepository;
+import com.example.skillup.domain.oauth.Entity.SocialLoginType;
 import com.example.skillup.domain.user.dto.request.UserRequest;
 import com.example.skillup.domain.user.dto.response.UserResponse;
 import com.example.skillup.domain.user.entity.Interest;
 import com.example.skillup.domain.user.entity.RecentSearch;
 import com.example.skillup.domain.user.entity.Users;
+import com.example.skillup.domain.user.enums.UserStatus;
 import com.example.skillup.domain.user.exception.UserErrorCode;
 import com.example.skillup.domain.user.exception.UserException;
 import com.example.skillup.domain.user.mappers.UserMapper;
@@ -23,12 +25,15 @@ import com.example.skillup.domain.user.repository.RecentSearchRepository;
 import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.domain.user.repository.WithdrawReasonCategoryRepository;
 import com.example.skillup.global.aop.ConvertNotFound;
+import com.example.skillup.global.auth.dto.response.TokenResponse;
+import com.example.skillup.global.auth.service.AuthService;
 import com.example.skillup.global.common.CommonResponse;
 import com.example.skillup.global.service.NotFoundGuardService;
 import com.example.skillup.global.service.S3Service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -56,6 +61,7 @@ public class UserService {
     private final S3Service s3Service;
     private final NotFoundGuardService notFoundGuardService;
     private final RecentSearchRepository recentSearchRepository;
+    private final AuthService authService;
 
     public UserResponse.MyPageHomeResponse getMyPageHome(Users user) {
         return userMapper.toMyPageHomeResponse(user);
@@ -208,5 +214,19 @@ public class UserService {
     @Transactional
     public void deleteAll(Long userId) {
         recentSearchRepository.deleteAllByUserId(userId);
+    }
+
+    @Transactional
+    public UserResponse.ContinueLoginResponse continueLogin(UserRequest.ContinueLoginRequest request)
+    {
+        Users user=userRepository.findBySocialLoginTypeAndSocialId
+                (SocialLoginType.valueOf(request.getSocialLoginType()),request.getSocialId()).orElse(null);
+
+        if(user.getStatus()== UserStatus.WITHDRAWN)
+            user.rejoin();
+
+        TokenResponse tokenResponse =authService.login(user.getEmail(),"users");
+
+        return UserResponse.ContinueLoginResponse.builder().accessToken(tokenResponse.accessToken()).build();
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->


**1.  OAuthLoginResponse 확장**
- OtherOauthUserInfo 추가
- WithdrawPendingUserInfo 추가


**2. 소셜 로그인 조회 로직 개선**
- socialLoginType + socialId 복합 식별자로 정합성 강화

**3.재로그인 API 추가**
- 다른 소셜 로그인 계정이 존재하여 그것으로 로그인하는 경우와 탈퇴 대기 상태에서 재로그인하는 경우, 두 상황 모두에서 사용하는 API입니다.
- 그래서 만약 다른 소셜 계정의 이메일이 탈퇴 대기 상태라면, 해당 탈퇴 상태를 철회(재가입 처리)한 뒤 로그인하도록 처리합니다.


## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
