### PR TITLE
[FIX] : 서비스 내에서 시간을 필드로 보관하여 값이 변하지 않는 에러 수정

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
@@ -17,12 +17,14 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventBannerService {
@@ -31,7 +33,6 @@ public class EventBannerService {
     private final BannerMapper bannerMapper;
     private final S3Service s3Service;
 
-    LocalDate now = LocalDate.now();
 
     @Transactional
     public EventResponse.EventBannerResponse createBanner(MultipartFile Banner,
@@ -52,6 +53,7 @@ public class EventBannerService {
     @Transactional(readOnly = true)
     public EventResponse.EventBannerAdminResponse getEventBanners(int page) {
 
+        LocalDate now = LocalDate.now();
 
         List<EventBanner> mainBanners = eventBannerRepository.findCurrentAndWaitingEventBannersByType(
                 BannerType.MAIN_BANNER, now);
@@ -68,6 +70,9 @@ public class EventBannerService {
     //실제 화면에 띄울 배너들 모음
     @Transactional(readOnly = true)
     public EventResponse.EventBannersResponseList getActiveEventBanners() {
+
+        LocalDate now = LocalDate.now();
+
         List<EventBanner> mainBanners = eventBannerRepository.findActiveEventBannersByType(BannerType.MAIN_BANNER, now);
 
         List<EventResponse.EventBannerResponse> activeEventBanners = bannerMapper.toEventBannerResponse(mainBanners);
@@ -105,6 +110,9 @@ public class EventBannerService {
 
     @Transactional
     public void updateBannerOrder(List<Long> bannerIds) {
+
+        LocalDate now = LocalDate.now();
+
         List<EventBanner> banners = eventBannerRepository.findByIdIn((bannerIds));
 
         if (banners.size() != bannerIds.size()) {

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -81,10 +81,6 @@ public class EventService {
     private final HashTagRepository hashTagRepository;
     private final EventPublishValidator eventPublishValidator;
 
-    LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
-    LocalDateTime now = LocalDateTime.now();
-    LocalDateTime twoMonthAgo = now.minusMonths(2);
-
 
     private record ActorInfo(String actorId, ActorType actorType) {
     }
@@ -383,6 +379,8 @@ public class EventService {
         String roleName = (tab == JobGroup.ALL) ? null : tab.getToKorean();
         String roleFilter = null;
 
+        LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
+
         if (roleName != null) {
             roleFilter = notFoundGuardService.getRole(roleName).getName();
         }
@@ -412,6 +410,7 @@ public class EventService {
 
     @Transactional(readOnly = true)
     public EventResponse.featuredEventResponseList getClosingSoonEvents(int size, UsersDetails user) {
+        LocalDateTime now = LocalDateTime.now();
         LocalDateTime due = now.plusDays(14);
 
         String roleName = null;
@@ -442,6 +441,9 @@ public class EventService {
                                                                               int page,
                                                                               int size, JobGroup tab,
                                                                               UsersDetails user) {
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime twoMonthAgo = now.minusMonths(2);
         Pageable pageable = PageRequest.of(page, size);
 
         List<EventRepository.PopularEventProjection> rows;
@@ -475,6 +477,8 @@ public class EventService {
     @HandleDataAccessException
     public EventResponse.SearchEventResponseList getEventBySearch(EventRequest.EventSearchCondition condition,
                                                                   UsersDetails user) {
+
+        LocalDateTime now = LocalDateTime.now();
         Pageable pageable = PageRequest.of(condition.getPage(), 12);
         List<EventRepositoryImpl.EventWithPopularity> events = findByCategoryWithSearch(condition, pageable);
 
@@ -531,6 +535,8 @@ public class EventService {
     @Transactional(readOnly = true)
     @HandleDataAccessException
     public EventHashTagResponse getRecommendedEvents(Long actorId, UsersDetails user) {
+
+        LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
         List<Event> events = eventRepository.findRecommendedEventForHome(actorId.toString(), actorId, since);
 
         List<Long> eventIds = events.stream().map(Event::getId).toList();
@@ -598,6 +604,8 @@ public class EventService {
 
     private List<EventRepositoryImpl.EventWithPopularity> findByCategoryWithSearch
             (EventRequest.EventSearchCondition condition, Pageable pageable) {
+        LocalDateTime since = LocalDate.now().minusMonths(3).atStartOfDay();
+        LocalDateTime now = LocalDateTime.now();
         return eventRepository.findByCategoryWithSearch
                 (condition, pageable, since, now);
     }
@@ -615,6 +623,7 @@ public class EventService {
     @Transactional(readOnly = true)
     public AdminEventPageResponse getAdminEventPage(AdminEventPageRequest request) {
 
+        LocalDateTime now = LocalDateTime.now();
         String keyword = request.getKeyword();
         if (keyword != null) {
             keyword = keyword.trim();


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

- `EventBannerService`, `EventService` 등에서 현재 날짜/시간을 Service 필드로 보관하던 로직 제거
- 현재 시간/날짜를 요청 시점(메서드 실행 시점)에 계산하도록 변경
- 시간 의존 쿼리/정렬/기간 판정 로직에서 사용되던 `now/since/twoMonthAgo`를 고정값이 아닌 동적 값으로 처리

## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
