### PR TITLE
[FIX]: 배너 필수값 및 크기 조정

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -238,12 +238,11 @@ public class EventRequest {
     @AllArgsConstructor
     public static class CreateEventBannerRequest {
 
-        @NotBlank
-        @Size(max = 20, message = "서브 타이틀은 최대 20자까지 입력할 수 있어요.")
+        @Size(max = 30, message = "서브 타이틀은 최대 20자까지 입력할 수 있어요.")
         private String subTitle;
 
         @NotBlank
-        @Size(max = 30, message = "메인 타이틀은 최대 30자까지 입력할 수 있어요.")
+        @Size(max = 50, message = "메인 타이틀은 최대 30자까지 입력할 수 있어요.")
         private String mainTitle;
 
         @Size(max = 50, message = "설명은 최대 50자까지 입력할 수 있어요.")
@@ -270,12 +269,11 @@ public class EventRequest {
     @AllArgsConstructor
     public static class UpdateEventBannerRequest {
 
-        @NotBlank
-        @Size(max = 20, message = "서브 타이틀은 최대 20자까지 입력할 수 있어요.")
+        @Size(max = 30, message = "서브 타이틀은 최대 20자까지 입력할 수 있어요.")
         private String subTitle;
 
         @NotBlank
-        @Size(max = 30, message = "메인 타이틀은 최대 30자까지 입력할 수 있어요.")
+        @Size(max = 50, message = "메인 타이틀은 최대 30자까지 입력할 수 있어요.")
         private String mainTitle;
 
         @Size(max = 50, message = "설명은 최대 50자까지 입력할 수 있어요.")

--- a/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
+++ b/src/main/java/com/example/skillup/domain/event/dto/request/EventRequest.java
@@ -238,11 +238,11 @@ public class EventRequest {
     @AllArgsConstructor
     public static class CreateEventBannerRequest {
 
-        @Size(max = 30, message = "서브 타이틀은 최대 20자까지 입력할 수 있어요.")
+        @Size(max = 30, message = "서브 타이틀은 최대 30자까지 입력할 수 있어요.")
         private String subTitle;
 
         @NotBlank
-        @Size(max = 50, message = "메인 타이틀은 최대 30자까지 입력할 수 있어요.")
+        @Size(max = 50, message = "메인 타이틀은 최대 50자까지 입력할 수 있어요.")
         private String mainTitle;
 
         @Size(max = 50, message = "설명은 최대 50자까지 입력할 수 있어요.")
@@ -269,11 +269,11 @@ public class EventRequest {
     @AllArgsConstructor
     public static class UpdateEventBannerRequest {
 
-        @Size(max = 30, message = "서브 타이틀은 최대 20자까지 입력할 수 있어요.")
+        @Size(max = 30, message = "서브 타이틀은 최대 30자까지 입력할 수 있어요.")
         private String subTitle;
 
         @NotBlank
-        @Size(max = 50, message = "메인 타이틀은 최대 30자까지 입력할 수 있어요.")
+        @Size(max = 50, message = "메인 타이틀은 최대 50자까지 입력할 수 있어요.")
         private String mainTitle;
 
         @Size(max = 50, message = "설명은 최대 50자까지 입력할 수 있어요.")

--- a/src/main/java/com/example/skillup/domain/event/entity/EventBanner.java
+++ b/src/main/java/com/example/skillup/domain/event/entity/EventBanner.java
@@ -39,10 +39,10 @@ public class EventBanner extends BaseEntity {
     @Column(nullable = false, length = 512)
     public String bannerImageUrl;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = 50)
     private String mainTitle;
 
-    @Column(nullable = false , length = 20)
+    @Column(length = 30)
     private String subTitle;
 
     @Column(nullable = false , length = 50)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

배너의 메인 타이틀을 최대 50자 서브 타이틀 필수값 제거 및 최대 30자로 수정했습니다.

## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
