### PR TITLE
[Fix] 행사 삭제 연관 테이블 정리, 검색 에러코드 세분화, COMPETITION_HACKATHON 카테고리 제거                                           

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/enums/EventCategory.java
+++ b/src/main/java/com/example/skillup/domain/event/enums/EventCategory.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum EventCategory {
     CONFERENCE_SEMINAR("컨퍼런스/세미나"),
-    COMPETITION_HACKATHON("공모전/해커톤"),
     BOOTCAMP_CLUB("부트캠프/동아리"),
     NETWORKING_MENTORING("네트워킹/멘토링"),
     ALL("전체"),;

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -29,9 +29,11 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class EventMapper {
 
@@ -198,7 +200,8 @@ public class EventMapper {
         if (eventDocument.getCategory() != null) {
             try {
                 category = EventCategory.valueOf(eventDocument.getCategory());
-            } catch (IllegalArgumentException ignore) {
+            } catch (IllegalArgumentException e) {
+                log.warn("지원하지 않는 카테고리 '{}' 발견 (eventId={})", eventDocument.getCategory(), eventDocument.getId());
             }
         }
 

--- a/src/main/java/com/example/skillup/domain/event/repository/EventActionRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventActionRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -28,6 +29,9 @@ public interface EventActionRepository extends JpaRepository<EventAction, Long> 
 
     Optional<EventAction> findByEventAndActorIdAndActionType(Event event, String actorId , ActionType actionType);
 
+    @Modifying
+    @Query("DELETE FROM EventAction ea WHERE ea.event.id = :eventId")
+    void deleteAllByEventId(@Param("eventId") Long eventId);
 
     @Query(value = """
     SELECT

--- a/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -46,6 +47,10 @@ public interface EventBookmarkRepository extends JpaRepository<EventBookmark, Lo
     """)
     List<Long> findBookmarkedEventIds(@Param("userId") Long userId,
                                       @Param("eventIds") List<Long> eventIds);
+
+    @Modifying
+    @Query("UPDATE EventBookmark eb SET eb.deletedAt = CURRENT_TIMESTAMP WHERE eb.event.id = :eventId AND eb.deletedAt IS NULL")
+    void softDeleteAllByEventId(@Param("eventId") Long eventId);
 
     @Query(value = """
     SELECT

--- a/src/main/java/com/example/skillup/domain/event/repository/EventLikeRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventLikeRepository.java
@@ -2,9 +2,16 @@ package com.example.skillup.domain.event.repository;
 
 import com.example.skillup.domain.event.entity.EventLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EventLikeRepository extends JpaRepository<EventLike, Long> {
     boolean existsByEventIdAndUserId(Long eventId, Long userId);
 
     void deleteByEventIdAndUserId(Long eventId, Long userId);
+
+    @Modifying
+    @Query("DELETE FROM EventLike el WHERE el.event.id = :eventId")
+    void deleteAllByEventId(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryImpl.java
@@ -101,8 +101,10 @@ public class EventRepositoryImpl implements EventRepositoryNative {
             default -> " ORDER BY popularity DESC";
         };
 
+        String categoryParam = cond.getCategory() == EventCategory.ALL ? null : cond.getCategory().name();
+
         Query query = entityManager.createNativeQuery(baseQuery + orderBy)
-                .setParameter("category", cond.getCategory().name())
+                .setParameter("category", categoryParam)
                 .setParameter("isOnline", cond.getIsOnline())
                 .setParameter("isFree", cond.getIsFree())
                 .setParameter("startDate", cond.getStartDate())

--- a/src/main/java/com/example/skillup/domain/event/repository/EventViewDailyRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventViewDailyRepository.java
@@ -40,4 +40,8 @@ public interface EventViewDailyRepository extends JpaRepository<EventViewDaily, 
     long sumLast14Days(@Param("eventId") Long eventId);
 
     Optional<EventViewDaily> findByEventAndViewDate(Event event, LocalDate viewDate);
+
+    @Modifying
+    @Query("DELETE FROM EventViewDaily v WHERE v.event.id = :eventId")
+    void deleteAllByEventId(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventBannerService.java
@@ -135,6 +135,10 @@ public class EventBannerService {
         int order = 1;
         for (Long id : bannerIds) {
             EventBanner banner = bannerMap.get(id);
+            if (banner == null) {
+                throw new EventException(EventErrorCode.INVALID_BANNER_ID,
+                        "배너 ID " + id + "에 해당하는 배너를 찾을 수 없습니다.");
+            }
             banner.updateBannerOrder(order++);
         }
 

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -25,6 +25,7 @@ import com.example.skillup.domain.event.repository.EventRepository;
 import com.example.skillup.domain.event.repository.EventRepository.AdminCategoryCountProjection;
 import com.example.skillup.domain.event.repository.EventRepository.AdminEventSummaryProjection;
 import com.example.skillup.domain.event.repository.EventRepositoryImpl;
+import com.example.skillup.domain.event.repository.EventViewDailyRepository;
 import com.example.skillup.domain.event.repository.HashTagRepository;
 import com.example.skillup.domain.event.validation.EventPublishValidator;
 import com.example.skillup.domain.map.provider.GeocodingProvider.GeoPoint;
@@ -38,6 +39,7 @@ import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.common.CommonResponse;
 import com.example.skillup.global.enums.JobGroup;
 import com.example.skillup.global.exception.CommonErrorCode;
+import com.example.skillup.global.search.exception.SearchException;
 import com.example.skillup.global.search.service.EventIndexerService;
 import com.example.skillup.global.service.AssociationBinder;
 import com.example.skillup.global.service.NotFoundGuardService;
@@ -76,6 +78,7 @@ public class EventService {
     private final AssociationBinder associationBinder;
     private final NotFoundGuardService notFoundGuardService;
     private final EventBookmarkRepository eventBookmarkRepository;
+    private final EventViewDailyRepository eventViewDailyRepository;
     private final UserRepository userRepository;
     private final GeocodingService geocodingService;
     private final HashTagRepository hashTagRepository;
@@ -88,21 +91,13 @@ public class EventService {
     private static final Map<EventCategory, List<EventCategory>> CATEGORY_PRIORITY = Map.of(
             EventCategory.CONFERENCE_SEMINAR, List.of(
                     EventCategory.NETWORKING_MENTORING,
-                    EventCategory.COMPETITION_HACKATHON,
                     EventCategory.BOOTCAMP_CLUB
             ),
             EventCategory.NETWORKING_MENTORING, List.of(
                     EventCategory.CONFERENCE_SEMINAR,
-                    EventCategory.COMPETITION_HACKATHON,
                     EventCategory.BOOTCAMP_CLUB
             ),
-            EventCategory.COMPETITION_HACKATHON, List.of(
-                    EventCategory.BOOTCAMP_CLUB,
-                    EventCategory.NETWORKING_MENTORING,
-                    EventCategory.CONFERENCE_SEMINAR
-            ),
             EventCategory.BOOTCAMP_CLUB, List.of(
-                    EventCategory.COMPETITION_HACKATHON,
                     EventCategory.NETWORKING_MENTORING,
                     EventCategory.CONFERENCE_SEMINAR
             )
@@ -218,10 +213,24 @@ public class EventService {
         if (event.getDeletedAt() != null) {
             throw new EventException(EventErrorCode.EVENT_ALREADY_DELETED, "EventID가 " + eventId + "는");
         }
-        //TODO eventbookmarked 및 eventaction 도 연동해서 지워야할듯
+
+        // 연관 테이블 정리
+        eventBookmarkRepository.softDeleteAllByEventId(eventId);
+        eventActionRepository.deleteAllByEventId(eventId);
+        eventViewDailyRepository.deleteAllByEventId(eventId);
+        eventLikeRepository.deleteAllByEventId(eventId);
+
+        // ManyToMany 중간 테이블 정리
+        event.getTargetRoles().clear();
+        event.getHashTags().clear();
+
         event.delete();
 
-        eventIndexerService.delete(event.getId());
+        try {
+            eventIndexerService.delete(event.getId());
+        } catch (SearchException e) {
+            log.error("행사(id={}) Elasticsearch 인덱스 삭제 실패: {}", event.getId(), e.getMessage());
+        }
 
         return new EventResponse.CommonEventResponse(event.getId());
     }
@@ -281,10 +290,14 @@ public class EventService {
 
         event.setStatus(status);
 
-        if (isVisible) {
-            eventIndexerService.index(event);
-        } else {
-            eventIndexerService.delete(event.getId());
+        try {
+            if (isVisible) {
+                eventIndexerService.index(event);
+            } else {
+                eventIndexerService.delete(event.getId());
+            }
+        } catch (Exception e) {
+            log.error("행사(id={}) 공개/숨김 처리 중 Elasticsearch 동기화 실패: {}", event.getId(), e.getMessage());
         }
 
         return new EventResponse.CommonEventResponse(event.getId());
@@ -468,7 +481,9 @@ public class EventService {
         String targetRoleKr = (targetRole == null || targetRole.equals(JobGroup.ALL)) ? null : targetRole.getToKorean();
         boolean targetRolesIsEmpty = (targetRoleKr == null || targetRoleKr.isEmpty());
 
-        int count = eventRepository.countByCategoryWithSearch(condition.getCategory().name(), condition.getIsOnline()
+        String categoryParam = condition.getCategory() == EventCategory.ALL ? null : condition.getCategory().name();
+
+        int count = eventRepository.countByCategoryWithSearch(categoryParam, condition.getIsOnline()
                 , condition.getIsFree(), condition.getStartDate(), condition.getEndDate(), targetRoleKr,
                 now,
                 targetRolesIsEmpty);

--- a/src/main/java/com/example/skillup/global/config/SampleDataLoader.java
+++ b/src/main/java/com/example/skillup/global/config/SampleDataLoader.java
@@ -107,7 +107,7 @@ public class SampleDataLoader implements CommandLineRunner {
 // B. 해커톤(30일 이내)
         Event hackathon = Event.builder()
                 .title("🚀 AI 해커톤 2025")
-                .category(EventCategory.COMPETITION_HACKATHON)
+                .category(EventCategory.CONFERENCE_SEMINAR)
                 .status(EventStatus.PUBLISHED)
                 .recruitStart(now.minusDays(3))
                 .recruitEnd(now.plusDays(7))

--- a/src/main/java/com/example/skillup/global/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/example/skillup/global/scheduler/UserCleanupScheduler.java
@@ -19,8 +19,8 @@ public class UserCleanupScheduler
     @Scheduled(cron = "0 0 4 * * *")
     @Transactional
     public void cleanupExpiredUsers() {
-        log.info("만료된 Guest 데이터 삭제 시작");
+        log.info("만료된 User 데이터 삭제 시작");
         userRepository.deleteExpiredUsers(LocalDateTime.now().minusWeeks(2));
-        log.info("만료된 Guest 데이터 삭제 완료");
+        log.info("만료된 User 데이터 삭제 완료");
     }
 }

--- a/src/main/java/com/example/skillup/global/search/exception/SearchErrorCode.java
+++ b/src/main/java/com/example/skillup/global/search/exception/SearchErrorCode.java
@@ -8,10 +8,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum SearchErrorCode implements ResultCode {
+    SEARCH_INDEX_CREATE_ERROR("SEARCH_INDEX_CREATE_ERROR", "행사 데이터 인덱싱(생성/수정) 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    SEARCH_INDEX_DELETE_ERROR("SEARCH_INDEX_DELETE_ERROR", "행사 데이터 인덱스 삭제 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    SEARCH_INDEX_BULK_ERROR("SEARCH_INDEX_BULK_ERROR", "행사 데이터 벌크 인덱싱 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
     SEARCH_INDEXING_ERROR("SEARCH_INDEXING_ERROR", "행사 데이터를 인덱싱 처리 과정에서의 에러가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
     SEARCH_SEARCH_QUERY_TOO_SHORT("SEARCH_SEARCH_QUERY_TOO_SHORT", "검색어는 2글자 이상 입력해 주세요.", HttpStatus.BAD_REQUEST),
-    SEARCH_SEARCH_ERROR("SEARCH_SEARCH_ERROR", "검색 기능 시 에러가 발생했습니다.", HttpStatus.BAD_REQUEST),
-    GROUP_ENTITY_NOT_FOUND("GROUP_ENTITY_NOT_FOUND","GRUOP 이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    SEARCH_SEARCH_ERROR("SEARCH_SEARCH_ERROR", "검색 서버와 통신 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    GROUP_ENTITY_NOT_FOUND("GROUP_ENTITY_NOT_FOUND", "그룹이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     SEARCH_DOCUMENT_SOURCE_NULL("SEARCH_DOCUMENT_SOURCE_NULL", "검색 결과 문서 데이터(_source)가 비어있습니다.", HttpStatus.SERVICE_UNAVAILABLE),
     ;
 

--- a/src/main/java/com/example/skillup/global/search/service/EventIndexerService.java
+++ b/src/main/java/com/example/skillup/global/search/service/EventIndexerService.java
@@ -47,8 +47,8 @@ public class EventIndexerService {
                     .refresh(Refresh.True)
             ));
         } catch (IOException e) {
-            throw new SearchException(SearchErrorCode.SEARCH_INDEXING_ERROR,
-                    e.getMessage() + "elasticsearch 생성/업데이트 시 에러 발생");
+            throw new SearchException(SearchErrorCode.SEARCH_INDEX_CREATE_ERROR,
+                    "행사(id=" + event.getId() + ") 인덱싱 실패: " + e.getMessage());
         }
     }
 
@@ -57,7 +57,8 @@ public class EventIndexerService {
         try {
             elasticsearchClient.delete(d -> d.index(index).id(String.valueOf(eventId)).refresh(Refresh.True));
         } catch (IOException e) {
-            throw new SearchException(SearchErrorCode.SEARCH_INDEXING_ERROR, "elasticsearch 인덱싱 삭제시 에러 발생");
+            throw new SearchException(SearchErrorCode.SEARCH_INDEX_DELETE_ERROR,
+                    "행사(id=" + eventId + ") 인덱스 삭제 실패: " + e.getMessage());
         }
     }
 
@@ -96,16 +97,19 @@ public class EventIndexerService {
                 var bulkResp = elasticsearchClient.bulk(
                         BulkRequest.of(b -> b.index(index).operations(ops).refresh(Refresh.True)));
                 if (Boolean.TRUE.equals(bulkResp.errors())) {
-                    throw new SearchException(SearchErrorCode.SEARCH_INDEXING_ERROR, "일부 문서 인덱싱 실패");
+                    throw new SearchException(SearchErrorCode.SEARCH_INDEX_BULK_ERROR,
+                            "벌크 인덱싱 중 일부 문서 실패 (page=" + page + ")");
                 }
                 total += ops.size();
                 page++;
             }
             return total;
         } catch (IOException e) {
-            throw new SearchException(SearchErrorCode.SEARCH_INDEXING_ERROR, "ES 통신 오류");
+            throw new SearchException(SearchErrorCode.SEARCH_INDEX_BULK_ERROR,
+                    "벌크 인덱싱 중 ES 통신 오류: " + e.getMessage());
         } catch (ElasticsearchException e) {
-            throw new SearchException(SearchErrorCode.SEARCH_INDEXING_ERROR, e.getMessage());
+            throw new SearchException(SearchErrorCode.SEARCH_INDEX_BULK_ERROR,
+                    "벌크 인덱싱 중 ES 오류: " + e.getMessage());
         }
     }
 }

--- a/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/event/service/EventServiceTest.java
@@ -313,7 +313,7 @@ public class EventServiceTest {
 
         EventRequest.UpdateEvent newRequest = new EventRequest.UpdateEvent(
                 "수정된 제목",
-                EventCategory.COMPETITION_HACKATHON,
+                EventCategory.CONFERENCE_SEMINAR,
                 LocalDateTime.of(2025, 10, 1, 14, 0),
                 LocalDateTime.of(2025, 10, 1, 16, 0),
                 LocalDateTime.of(2025, 9, 15, 0, 0),
@@ -357,7 +357,7 @@ public class EventServiceTest {
         Event updatedEvent = eventRepository.getEvent(eventId);
         assertThat(updatedEvent.getTitle()).isEqualTo("수정된 제목");
         assertThat(updatedEvent.getThumbnailUrl()).endsWith("new.jpg");
-        assertThat(updatedEvent.getCategory()).isEqualTo(EventCategory.COMPETITION_HACKATHON);
+        assertThat(updatedEvent.getCategory()).isEqualTo(EventCategory.CONFERENCE_SEMINAR);
         assertThat(updatedEvent.getEventStart()).isEqualTo(LocalDateTime.of(2025, 10, 1, 14, 0));
         assertThat(updatedEvent.getEventEnd()).isEqualTo(LocalDateTime.of(2025, 10, 1, 16, 0));
         assertThat(updatedEvent.getRecruitStart()).isEqualTo(LocalDateTime.of(2025, 9, 15, 0, 0));
@@ -605,7 +605,7 @@ public class EventServiceTest {
     @Test
     @DisplayName("행사 추천 기존 카테고리가 2개 이하여서 다른 카테고리로 보충 성공 테스트")
     public void getSupplementaryEvents_Success() {
-        Event savedEvent1 = eventRepository.save(createEvent("저장", EventCategory.COMPETITION_HACKATHON));
+        Event savedEvent1 = eventRepository.save(createEvent("저장", EventCategory.CONFERENCE_SEMINAR));
         Event savedEvent2 = eventRepository.save(createEvent("저장", EventCategory.CONFERENCE_SEMINAR));
         Event savedEvent3 = eventRepository.save(createEvent("저장", EventCategory.NETWORKING_MENTORING));
 


### PR DESCRIPTION
## 개요
                                      
   
  변경 사항                                                                                                                            
  - 행사 삭제 시 Bookmark, Action, Like, ViewDaily 등 연관 테이블 함께 정리되도록 수정
  - ES 인덱스 삭제 실패해도 행사 삭제는 정상 처리되도록 예외 처리
  - 검색 에러코드 세분화 (CREATE, DELETE, BULK 분리)
  - COMPETITION_HACKATHON 카테고리 제거 및 ALL 카테고리 필터링 처리
  - 배너 null 방어 코드, 카테고리 파싱 실패 로그 추가





## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
