### PR TITLE
[FIX] : 행사명 중복시 error 반환 추가 및 최신순 정렬시 created_at 가 아닌 published_at 로 변경

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/entity/Event.java
+++ b/src/main/java/com/example/skillup/domain/event/entity/Event.java
@@ -132,6 +132,10 @@ public class Event extends BaseEntity {
     @Column(name = "ad_flag", nullable = false)
     private boolean ad = false;                // 광고/제휴 노출 여부
 
+    // 실제 등록 시각
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
 
     public void addTargetRole(TargetRole role) {
         targetRoles.add(role);

--- a/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/example/skillup/domain/event/mapper/EventMapper.java
@@ -65,6 +65,7 @@ public class EventMapper {
                 .status(EventStatus.PUBLISHED)
                 .latitude(lat)
                 .longitude(lng)
+                .publishedAt(LocalDateTime.now().withNano(0))
                 .build();
     }
 
@@ -330,7 +331,7 @@ public class EventMapper {
                             .viewsCount(event.getViewsCount())
                             .bookmarksCount(event.getBookmarkedCount())
                             .status(status.getToKorean())
-                            .createdAt(event.getCreatedAt())
+                            .createdAt(event.getPublishedAt())
                             .build();
                 }
         ).toList();

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepository.java
@@ -20,6 +20,8 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
         return findById(eventId).orElseThrow(
                 () -> new EventException(EventErrorCode.EVENT_ENTITY_NOT_FOUND, "EventID 가 " + eventId + "인"));
     }
+    boolean existsByTitle(String title);
+    boolean existsByTitleAndIdNot(String title, Long eventId);
 
     Page<Event> findAllByCategoryIn(Set<EventCategory> categories, Pageable pageable);
 
@@ -212,6 +214,8 @@ public interface EventRepository extends JpaRepository<Event, Long>, EventReposi
             Pageable pageable);
 
     Page<Event> findByStatus(EventStatus status, Pageable pageable);
+
+
 
     public interface PopularEventProjection {
         Event getEvent();

--- a/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventRepositoryImpl.java
@@ -97,7 +97,7 @@ public class EventRepositoryImpl implements EventRepositoryNative {
 
 
         String orderBy = switch (cond.getSort().name()) {
-            case "LATEST" -> " ORDER BY e.created_at DESC";
+            case "LATEST" -> " ORDER BY e.published_at DESC";
             case "DEADLINE" -> " ORDER BY e.recruit_end ASC";
             default -> " ORDER BY popularity DESC";
         };

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -111,6 +111,8 @@ public class EventService {
     @Transactional
     public Event createEvent(EventRequest.CreateEvent request, MultipartFile thumbnailImage) {
 
+        eventPublishValidator.validateDuplicateTitleForCreate(request.getTitle());
+
         String thumbnailUrl = null;
 
         if (thumbnailImage != null) {
@@ -144,6 +146,8 @@ public class EventService {
     @Transactional
     public Event createDraftEvent(EventRequest.CreateDraftEvent request, MultipartFile thumbnailImage) {
 
+        eventPublishValidator.validateDuplicateTitleForCreate(request.getTitle());
+
         String thumbnailUrl = null;
         if (thumbnailImage != null) {
             thumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
@@ -166,9 +170,7 @@ public class EventService {
     public Event publishDraftEvent(Long eventId , UpdateEvent request, MultipartFile thumbnailImage) {
         Event event = eventRepository.getEvent(eventId);
 
-        if(event.getStatus() != EventStatus.DRAFT) {
-            throw new EventException(EventErrorCode.EVENT_ALREADY_PUBLISHED);
-        }
+        eventPublishValidator.validateDuplicateTitleForUpdate(eventId , request.getTitle());
 
         String thumbnailUrl = event.getThumbnailUrl();
         if (thumbnailImage != null && !thumbnailImage.isEmpty()) {

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -197,6 +197,8 @@ public class EventService {
         }
 
         event.setStatus(EventStatus.PUBLISHED);
+        event.setPublishedAt(LocalDateTime.now().withNano(0));
+
         Event savedEvent = eventRepository.save(event);
 
         eventIndexerService.index(savedEvent);
@@ -663,7 +665,7 @@ public class EventService {
             case EVENT_START -> Sort.by(Sort.Direction.ASC, "eventStart");
             case VIEWS -> Sort.by(Sort.Direction.DESC, "viewsCount");
             case BOOKMARKS -> Sort.by(Sort.Direction.DESC, "bookmarkedCount");
-            case CREATED_AT -> Sort.by(Sort.Direction.DESC, "createdAt");
+            case CREATED_AT -> Sort.by(Sort.Direction.DESC, "publishedAt");
 
             default -> throw new EventException(EventErrorCode.INVALID_EVENT_SORT_TYPE, sortType.name() + "은 ");
         };

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -243,8 +243,14 @@ public class EventService {
         Event event = eventRepository.getEvent(eventId);
 
         String oldLocationText = event.getLocationText();
+        String oldTitle = event.getTitle();
         Boolean oldIsOnline = event.getIsOnline();
         String imageUrl = event.getThumbnailUrl();
+
+
+        if (request.getTitle() != null && !request.getTitle().equals(oldTitle)) {
+            eventPublishValidator.validateDuplicateTitleForUpdate(event.getId(), request.getTitle());
+        }
 
         if (thumbnailImage != null && !thumbnailImage.isEmpty()) {
 

--- a/src/main/java/com/example/skillup/domain/event/validation/EventPublishValidator.java
+++ b/src/main/java/com/example/skillup/domain/event/validation/EventPublishValidator.java
@@ -3,10 +3,15 @@ package com.example.skillup.domain.event.validation;
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.exception.EventErrorCode;
 import com.example.skillup.domain.event.exception.EventException;
+import com.example.skillup.domain.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class EventPublishValidator {
+
+    private final EventRepository eventRepository;
 
     public void validateForPublish(Event event) {
 
@@ -42,6 +47,18 @@ public class EventPublishValidator {
                 throw new EventException(EventErrorCode.EVENT_PUBLISH_VALIDATION_FAILED,
                         "오프라인 행사는 장소(locationText)가 필수입니다.");
             }
+        }
+    }
+
+    public void validateDuplicateTitleForCreate(String title) {
+        if (eventRepository.existsByTitle(title)) {
+            throw new EventException(EventErrorCode.EVENT_ALREADY_PUBLISHED , title + "인 행사가 이미 존재합니다.");
+        }
+    }
+
+    public void validateDuplicateTitleForUpdate(Long eventId, String title) {
+        if (eventRepository.existsByTitleAndIdNot(title, eventId)) {
+            throw new EventException(EventErrorCode.EVENT_ALREADY_PUBLISHED , title + "인 행사가  이미 존재합니다.");
         }
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

- 동일한 행사명이 이미 존재하는 경우 예외가 발생하도록 중복 검증 로직을 추가했습니다.
- 임시저장 후 등록한 행사도 실제 등록 시점 기준으로 정렬될 수 있도록 `publishedAt` 필드를 추가했습니다.
- 관리자 페이지의 등록된 행사 목록 정렬 기준 및 카테고리 검색 시  등록 시점을 반영할 수 있도록 수정했습니다.

## 변경 이유
기존에는 관리자 페이지에서 등록된 행사 목록을 `createdAt` 기준으로 정렬하고 있어,
임시저장 상태로 먼저 생성된 뒤 나중에 등록된 행사의 경우 실제 등록 순서와 목록 정렬 순서가 달라지는 문제가 있었습니다.

기존 데이터의 published_at 는 created_at 로 먼저 맞춰두고 이후 저장되는 행사들의 경우 등록시에 published_at 를 추가하는 방향으로 했습니다.

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
