### PR TITLE
[FEAT] : 트랜잭션 이벤트 기반 S3/Elasticsearch 후처리 적용 및 재가입 로직 수정

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/events/EventCreatedEvent.java
+++ b/src/main/java/com/example/skillup/domain/event/events/EventCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.example.skillup.domain.event.events;
+
+public record EventCreatedEvent(Long eventId) {
+}

--- a/src/main/java/com/example/skillup/domain/event/events/ThumbnailReplacedEvent.java
+++ b/src/main/java/com/example/skillup/domain/event/events/ThumbnailReplacedEvent.java
@@ -1,4 +1,6 @@
 package com.example.skillup.domain.event.events;
 
-public record ThumbnailReplacedEvent(String oldThumbnailUrl) {
+import com.example.skillup.global.recovery.enums.ResourceType;
+
+public record ThumbnailReplacedEvent(ResourceType resourceType,Long resourceId, String oldThumbnailUrl) {
 }

--- a/src/main/java/com/example/skillup/domain/event/events/ThumbnailReplacedEvent.java
+++ b/src/main/java/com/example/skillup/domain/event/events/ThumbnailReplacedEvent.java
@@ -1,0 +1,4 @@
+package com.example.skillup.domain.event.events;
+
+public record ThumbnailReplacedEvent(String oldThumbnailUrl) {
+}

--- a/src/main/java/com/example/skillup/domain/event/events/ThumbnailUploadedEvent.java
+++ b/src/main/java/com/example/skillup/domain/event/events/ThumbnailUploadedEvent.java
@@ -1,0 +1,4 @@
+package com.example.skillup.domain.event.events;
+
+public record ThumbnailUploadedEvent(String thumbnailUrl) {
+}

--- a/src/main/java/com/example/skillup/domain/event/events/ThumbnailUploadedEvent.java
+++ b/src/main/java/com/example/skillup/domain/event/events/ThumbnailUploadedEvent.java
@@ -1,4 +1,6 @@
 package com.example.skillup.domain.event.events;
 
-public record ThumbnailUploadedEvent(String thumbnailUrl) {
+import com.example.skillup.global.recovery.enums.ResourceType;
+
+public record ThumbnailUploadedEvent(ResourceType resourceType, String thumbnailUrl) {
 }

--- a/src/main/java/com/example/skillup/domain/event/listener/EventIndexingListener.java
+++ b/src/main/java/com/example/skillup/domain/event/listener/EventIndexingListener.java
@@ -1,0 +1,29 @@
+package com.example.skillup.domain.event.listener;
+
+import com.example.skillup.domain.event.entity.Event;
+import com.example.skillup.domain.event.events.EventCreatedEvent;
+import com.example.skillup.domain.event.repository.EventRepository;
+import com.example.skillup.global.search.service.EventIndexerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EventIndexingListener {
+    private final EventIndexerService eventIndexerService;
+    private final EventRepository eventRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void indexEventAfterCommit(EventCreatedEvent event) {
+
+        log.info("AFTER_COMMIT 실행 - eventId={}", event.eventId());
+
+        Event savedEvent = eventRepository.getEvent(event.eventId());
+
+        eventIndexerService.index(savedEvent);
+    }
+}

--- a/src/main/java/com/example/skillup/domain/event/listener/EventIndexingListener.java
+++ b/src/main/java/com/example/skillup/domain/event/listener/EventIndexingListener.java
@@ -20,7 +20,7 @@ public class EventIndexingListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void indexEventAfterCommit(EventCreatedEvent event) {
 
-        log.info("AFTER_COMMIT 실행 - eventId={}", event.eventId());
+        log.info("ES AFTER_COMMIT 실행 - eventId={}", event.eventId());
 
         Event savedEvent = eventRepository.getEvent(event.eventId());
 

--- a/src/main/java/com/example/skillup/domain/event/listener/EventIndexingListener.java
+++ b/src/main/java/com/example/skillup/domain/event/listener/EventIndexingListener.java
@@ -1,8 +1,12 @@
 package com.example.skillup.domain.event.listener;
 
+import static com.example.skillup.global.common.CommonMapper.normalizeReason;
+
 import com.example.skillup.domain.event.entity.Event;
 import com.example.skillup.domain.event.events.EventCreatedEvent;
 import com.example.skillup.domain.event.repository.EventRepository;
+import com.example.skillup.global.recovery.enums.ResourceType;
+import com.example.skillup.global.recovery.service.SearchIndexFailureSaveService;
 import com.example.skillup.global.search.service.EventIndexerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,14 +20,25 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class EventIndexingListener {
     private final EventIndexerService eventIndexerService;
     private final EventRepository eventRepository;
+    private final SearchIndexFailureSaveService searchIndexFailureSaveService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void indexEventAfterCommit(EventCreatedEvent event) {
+        try {
+            log.info("ES AFTER_COMMIT 실행 - eventId={}", event.eventId());
 
-        log.info("ES AFTER_COMMIT 실행 - eventId={}", event.eventId());
+            Event savedEvent = eventRepository.getEvent(event.eventId());
 
-        Event savedEvent = eventRepository.getEvent(event.eventId());
-
-        eventIndexerService.index(savedEvent);
+            eventIndexerService.index(savedEvent);
+        } catch (Exception e) {
+            log.error("이벤트 인덱싱 실패 - eventId={}", event.eventId(), e);
+            searchIndexFailureSaveService.saveFailure(
+                    ResourceType.EVENT,
+                    event.eventId(),
+                    "events_v3",
+                    String.valueOf(event.eventId()),
+                    normalizeReason(e, "Elastic Search 인덱싱 실패")
+            );
+        }
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/listener/S3RollbackCleanupListener.java
+++ b/src/main/java/com/example/skillup/domain/event/listener/S3RollbackCleanupListener.java
@@ -1,7 +1,10 @@
 package com.example.skillup.domain.event.listener;
 
+import static com.example.skillup.global.common.CommonMapper.normalizeReason;
+
 import com.example.skillup.domain.event.events.ThumbnailReplacedEvent;
 import com.example.skillup.domain.event.events.ThumbnailUploadedEvent;
+import com.example.skillup.global.recovery.service.FileCleanupFailureSaveService;
 import com.example.skillup.global.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,16 +17,44 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class S3RollbackCleanupListener {
     private final S3Service s3Service;
+    private final FileCleanupFailureSaveService fileCleanupFailureSaveService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     public void deleteThumbnailOnRollback(ThumbnailUploadedEvent event) {
-        log.info("S3 AFTER_ROLLBACK 실행 - thumbnailUrl={}", event.thumbnailUrl());
-        s3Service.deleteFileFromUrl(event.thumbnailUrl());
+        try {
+            log.info("S3 AFTER_ROLLBACK 실행 - thumbnailUrl={}", event.thumbnailUrl());
+            s3Service.deleteFileFromUrl(event.thumbnailUrl());
+        } catch (Exception e) {
+            log.error("롤백 후 S3 삭제 실패 - thumbnailUrl={}", event.thumbnailUrl(), e);
+
+            fileCleanupFailureSaveService.saveFailure(
+                    event.resourceType(),
+                    null,
+                    event.thumbnailUrl(),
+                    null,
+                    null,
+                    normalizeReason(e, "S3 이미지 롤백 실패")
+            );
+        }
+
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteThumbnailOnCommit(ThumbnailReplacedEvent event) {
-        log.info("S3 AFTER_COMMIT 실행 - thumbnailUrl={}", event.oldThumbnailUrl());
-        s3Service.deleteFileFromUrl(event.oldThumbnailUrl());
+        try {
+            log.info("S3 AFTER_COMMIT 실행 - thumbnailUrl={}", event.oldThumbnailUrl());
+            s3Service.deleteFileFromUrl(event.oldThumbnailUrl());
+        } catch (Exception e) {
+            log.error("커밋 후 기존 썸네일 삭제 실패 - oldThumbnailUrl={}", event.oldThumbnailUrl(), e);
+
+            fileCleanupFailureSaveService.saveFailure(
+                    event.resourceType(),
+                    event.resourceId(),
+                    event.oldThumbnailUrl(),
+                    null,
+                    null,
+                    normalizeReason(e, "S3 기존 썸네일 삭제 실패")
+            );
+        }
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/listener/S3RollbackCleanupListener.java
+++ b/src/main/java/com/example/skillup/domain/event/listener/S3RollbackCleanupListener.java
@@ -1,5 +1,6 @@
 package com.example.skillup.domain.event.listener;
 
+import com.example.skillup.domain.event.events.ThumbnailReplacedEvent;
 import com.example.skillup.domain.event.events.ThumbnailUploadedEvent;
 import com.example.skillup.global.service.S3Service;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,13 @@ public class S3RollbackCleanupListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     public void deleteThumbnailOnRollback(ThumbnailUploadedEvent event) {
-        log.info("AFTER_ROLLBACK 실행 - thumbnailUrl={}", event.thumbnailUrl());
+        log.info("S3 AFTER_ROLLBACK 실행 - thumbnailUrl={}", event.thumbnailUrl());
         s3Service.deleteFileFromUrl(event.thumbnailUrl());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void deleteThumbnailOnCommit(ThumbnailReplacedEvent event) {
+        log.info("S3 AFTER_COMMIT 실행 - thumbnailUrl={}", event.oldThumbnailUrl());
+        s3Service.deleteFileFromUrl(event.oldThumbnailUrl());
     }
 }

--- a/src/main/java/com/example/skillup/domain/event/listener/S3RollbackCleanupListener.java
+++ b/src/main/java/com/example/skillup/domain/event/listener/S3RollbackCleanupListener.java
@@ -1,0 +1,22 @@
+package com.example.skillup.domain.event.listener;
+
+import com.example.skillup.domain.event.events.ThumbnailUploadedEvent;
+import com.example.skillup.global.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3RollbackCleanupListener {
+    private final S3Service s3Service;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    public void deleteThumbnailOnRollback(ThumbnailUploadedEvent event) {
+        log.info("AFTER_ROLLBACK 실행 - thumbnailUrl={}", event.thumbnailUrl());
+        s3Service.deleteFileFromUrl(event.thumbnailUrl());
+    }
+}

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -15,6 +15,8 @@ import com.example.skillup.domain.event.enums.ActorType;
 import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventSortType;
 import com.example.skillup.domain.event.enums.EventStatus;
+import com.example.skillup.domain.event.events.EventCreatedEvent;
+import com.example.skillup.domain.event.events.ThumbnailUploadedEvent;
 import com.example.skillup.domain.event.exception.EventErrorCode;
 import com.example.skillup.domain.event.exception.EventException;
 import com.example.skillup.domain.event.mapper.EventMapper;
@@ -54,6 +56,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -83,6 +86,7 @@ public class EventService {
     private final GeocodingService geocodingService;
     private final HashTagRepository hashTagRepository;
     private final EventPublishValidator eventPublishValidator;
+    private final ApplicationEventPublisher eventPublisher;
 
 
     private record ActorInfo(String actorId, ActorType actorType) {
@@ -113,18 +117,12 @@ public class EventService {
 
         eventPublishValidator.validateDuplicateTitleForCreate(request.getTitle());
 
-        String thumbnailUrl = null;
-
-        if (thumbnailImage != null) {
-            thumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
-        }
-
         GeoPoint eventGeoPoint = null;
         if (!request.getIsOnline()) {
-            eventGeoPoint = new GeoPoint(request.getLatitude() , request.getLongitude() , request.getLocationText());
+            eventGeoPoint = new GeoPoint(request.getLatitude(), request.getLongitude(), request.getLocationText());
         }
 
-        Event event = eventMapper.toEntity(request, thumbnailUrl, eventGeoPoint);
+        Event event = eventMapper.toEntity(request, null, eventGeoPoint);
 
         if (request.getTargetRoles() != null && !request.getTargetRoles().isEmpty()) {
             associationBinder.bindRoles(request.getTargetRoles(), event::addTargetRole);
@@ -136,9 +134,19 @@ public class EventService {
 
         eventPublishValidator.validateForPublish(event);
 
+        if (thumbnailImage != null) {
+            String thumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
+
+            event.setThumbnailUrl(thumbnailUrl);
+
+            // 롤백되면 S3 올라간 데이터 삭제
+            eventPublisher.publishEvent(new ThumbnailUploadedEvent(thumbnailUrl));
+        }
+
         Event savedEvent = eventRepository.save(event);
 
-        eventIndexerService.index(savedEvent);
+        //DB 에 저장된게 확인되면 elastic search 에 올라가도록 수정
+        eventPublisher.publishEvent(new EventCreatedEvent(savedEvent.getId()));
 
         return savedEvent;
     }
@@ -167,10 +175,10 @@ public class EventService {
     }
 
     @Transactional
-    public Event publishDraftEvent(Long eventId , UpdateEvent request, MultipartFile thumbnailImage) {
+    public Event publishDraftEvent(Long eventId, UpdateEvent request, MultipartFile thumbnailImage) {
         Event event = eventRepository.getEvent(eventId);
 
-        eventPublishValidator.validateDuplicateTitleForUpdate(eventId , request.getTitle());
+        eventPublishValidator.validateDuplicateTitleForUpdate(eventId, request.getTitle());
 
         String thumbnailUrl = event.getThumbnailUrl();
         if (thumbnailImage != null && !thumbnailImage.isEmpty()) {
@@ -190,7 +198,6 @@ public class EventService {
         }
 
         eventPublishValidator.validateForPublish(event);
-
 
         if (Boolean.FALSE.equals(event.getIsOnline())) {
             event.updateCoordinates(request.getLatitude(), request.getLongitude());
@@ -248,7 +255,6 @@ public class EventService {
         String oldTitle = event.getTitle();
         Boolean oldIsOnline = event.getIsOnline();
         String imageUrl = event.getThumbnailUrl();
-
 
         if (request.getTitle() != null && !request.getTitle().equals(oldTitle)) {
             eventPublishValidator.validateDuplicateTitleForUpdate(event.getId(), request.getTitle());

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -16,6 +16,7 @@ import com.example.skillup.domain.event.enums.EventCategory;
 import com.example.skillup.domain.event.enums.EventSortType;
 import com.example.skillup.domain.event.enums.EventStatus;
 import com.example.skillup.domain.event.events.EventCreatedEvent;
+import com.example.skillup.domain.event.events.ThumbnailReplacedEvent;
 import com.example.skillup.domain.event.events.ThumbnailUploadedEvent;
 import com.example.skillup.domain.event.exception.EventErrorCode;
 import com.example.skillup.domain.event.exception.EventException;
@@ -156,12 +157,7 @@ public class EventService {
 
         eventPublishValidator.validateDuplicateTitleForCreate(request.getTitle());
 
-        String thumbnailUrl = null;
-        if (thumbnailImage != null) {
-            thumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
-        }
-
-        Event event = eventMapper.toDraftEntity(request, thumbnailUrl);
+        Event event = eventMapper.toDraftEntity(request, null);
 
         if (request.getTargetRoles() != null && !request.getTargetRoles().isEmpty()) {
             associationBinder.bindRoles(request.getTargetRoles(), event::addTargetRole);
@@ -169,6 +165,14 @@ public class EventService {
 
         if (request.getHashTags() != null && !request.getHashTags().isEmpty()) {
             associationBinder.bindHashTags(request.getHashTags(), event::addHashTag);
+        }
+
+        if (thumbnailImage != null) {
+            String thumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
+
+            event.setThumbnailUrl(thumbnailUrl);
+
+            eventPublisher.publishEvent(new ThumbnailUploadedEvent(thumbnailUrl));
         }
 
         return eventRepository.save(event);
@@ -180,12 +184,9 @@ public class EventService {
 
         eventPublishValidator.validateDuplicateTitleForUpdate(eventId, request.getTitle());
 
-        String thumbnailUrl = event.getThumbnailUrl();
-        if (thumbnailImage != null && !thumbnailImage.isEmpty()) {
-            thumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
-        }
+        String oldThumbnailUrl = event.getThumbnailUrl();
 
-        event.update(request, thumbnailUrl);
+        event.update(request, oldThumbnailUrl);
 
         if (request.getTargetRoles() != null && !request.getTargetRoles().isEmpty()) {
             event.getTargetRoles().clear();
@@ -197,10 +198,23 @@ public class EventService {
             associationBinder.bindHashTags(request.getHashTags(), event::addHashTag);
         }
 
-        eventPublishValidator.validateForPublish(event);
-
         if (Boolean.FALSE.equals(event.getIsOnline())) {
             event.updateCoordinates(request.getLatitude(), request.getLongitude());
+        }
+
+        eventPublishValidator.validateForPublish(event);
+
+        if (thumbnailImage != null && !thumbnailImage.isEmpty()) {
+            String newThumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
+
+            event.setThumbnailUrl(newThumbnailUrl);
+
+            eventPublisher.publishEvent(new ThumbnailUploadedEvent(newThumbnailUrl));
+
+            //제대로 저장되는 경우 기존 썸네일 삭제
+            if (oldThumbnailUrl != null && !oldThumbnailUrl.isBlank()) {
+                eventPublisher.publishEvent(new ThumbnailReplacedEvent(oldThumbnailUrl));
+            }
         }
 
         event.setStatus(EventStatus.PUBLISHED);
@@ -208,7 +222,7 @@ public class EventService {
 
         Event savedEvent = eventRepository.save(event);
 
-        eventIndexerService.index(savedEvent);
+        eventPublisher.publishEvent(new EventCreatedEvent(savedEvent.getId()));
 
         return savedEvent;
     }
@@ -254,22 +268,13 @@ public class EventService {
         String oldLocationText = event.getLocationText();
         String oldTitle = event.getTitle();
         Boolean oldIsOnline = event.getIsOnline();
-        String imageUrl = event.getThumbnailUrl();
+        String oldThumbnailUrl = event.getThumbnailUrl();
 
         if (request.getTitle() != null && !request.getTitle().equals(oldTitle)) {
             eventPublishValidator.validateDuplicateTitleForUpdate(event.getId(), request.getTitle());
         }
 
-        if (thumbnailImage != null && !thumbnailImage.isEmpty()) {
-
-            if (imageUrl != null && !imageUrl.isEmpty()) {
-                s3Service.deleteFileFromUrl(imageUrl);
-            }
-
-            imageUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
-        }
-
-        event.update(request, imageUrl);
+        event.update(request, oldThumbnailUrl);
 
         boolean locationChanged =
                 request.getLocationText() != null && !request.getLocationText().equals(oldLocationText);
@@ -292,7 +297,19 @@ public class EventService {
 
         eventPublishValidator.validateForPublish(event);
 
-        eventIndexerService.index(event);
+        if (thumbnailImage != null && !thumbnailImage.isEmpty()) {
+            String newThumbnailUrl = s3Service.uploadFile(thumbnailImage, "event/thumbnail");
+
+            event.setThumbnailUrl(newThumbnailUrl);
+
+            eventPublisher.publishEvent(new ThumbnailUploadedEvent(newThumbnailUrl));
+
+            if (oldThumbnailUrl != null && !oldThumbnailUrl.isBlank()) {
+                eventPublisher.publishEvent(new ThumbnailReplacedEvent(oldThumbnailUrl));
+            }
+        }
+
+        eventPublisher.publishEvent(new EventCreatedEvent(event.getId()));
 
         return new EventResponse.CommonEventResponse(event.getId());
     }

--- a/src/main/java/com/example/skillup/domain/event/service/EventService.java
+++ b/src/main/java/com/example/skillup/domain/event/service/EventService.java
@@ -42,6 +42,7 @@ import com.example.skillup.global.common.CommonMapper;
 import com.example.skillup.global.common.CommonResponse;
 import com.example.skillup.global.enums.JobGroup;
 import com.example.skillup.global.exception.CommonErrorCode;
+import com.example.skillup.global.recovery.enums.ResourceType;
 import com.example.skillup.global.search.exception.SearchException;
 import com.example.skillup.global.search.service.EventIndexerService;
 import com.example.skillup.global.service.AssociationBinder;
@@ -141,7 +142,7 @@ public class EventService {
             event.setThumbnailUrl(thumbnailUrl);
 
             // 롤백되면 S3 올라간 데이터 삭제
-            eventPublisher.publishEvent(new ThumbnailUploadedEvent(thumbnailUrl));
+            eventPublisher.publishEvent(new ThumbnailUploadedEvent(ResourceType.EVENT, thumbnailUrl));
         }
 
         Event savedEvent = eventRepository.save(event);
@@ -172,7 +173,7 @@ public class EventService {
 
             event.setThumbnailUrl(thumbnailUrl);
 
-            eventPublisher.publishEvent(new ThumbnailUploadedEvent(thumbnailUrl));
+            eventPublisher.publishEvent(new ThumbnailUploadedEvent(ResourceType.EVENT, thumbnailUrl));
         }
 
         return eventRepository.save(event);
@@ -209,11 +210,12 @@ public class EventService {
 
             event.setThumbnailUrl(newThumbnailUrl);
 
-            eventPublisher.publishEvent(new ThumbnailUploadedEvent(newThumbnailUrl));
+            eventPublisher.publishEvent(new ThumbnailUploadedEvent(ResourceType.EVENT, newThumbnailUrl));
 
             //제대로 저장되는 경우 기존 썸네일 삭제
             if (oldThumbnailUrl != null && !oldThumbnailUrl.isBlank()) {
-                eventPublisher.publishEvent(new ThumbnailReplacedEvent(oldThumbnailUrl));
+                eventPublisher.publishEvent(
+                        new ThumbnailReplacedEvent(ResourceType.EVENT, event.getId(), oldThumbnailUrl));
             }
         }
 
@@ -302,10 +304,11 @@ public class EventService {
 
             event.setThumbnailUrl(newThumbnailUrl);
 
-            eventPublisher.publishEvent(new ThumbnailUploadedEvent(newThumbnailUrl));
+            eventPublisher.publishEvent(new ThumbnailUploadedEvent(ResourceType.EVENT, newThumbnailUrl));
 
             if (oldThumbnailUrl != null && !oldThumbnailUrl.isBlank()) {
-                eventPublisher.publishEvent(new ThumbnailReplacedEvent(oldThumbnailUrl));
+                eventPublisher.publishEvent(
+                        new ThumbnailReplacedEvent(ResourceType.EVENT, event.getId(), oldThumbnailUrl));
             }
         }
 

--- a/src/main/java/com/example/skillup/domain/user/entity/Users.java
+++ b/src/main/java/com/example/skillup/domain/user/entity/Users.java
@@ -114,9 +114,10 @@ public class Users extends BaseEntity
         this.lastLoginAt = lastLoginAt;
     }
 
-    public void rejoin()
-    {
-        this.status= UserStatus.ACTIVE;
+    public void rejoin() {
+        this.status = UserStatus.ACTIVE;
+        this.withDrawReason = null;
+        this.restore();
     }
 
 

--- a/src/main/java/com/example/skillup/global/common/BaseEntity.java
+++ b/src/main/java/com/example/skillup/global/common/BaseEntity.java
@@ -25,13 +25,18 @@ public abstract class BaseEntity {
         deletedAt = LocalDateTime.now();
     }
 
+    public void restore() {
+        deletedAt = null;
+    }
+
     @PrePersist
     public void prePersist() {
         if (createdAt == null) {
             createdAt = LocalDateTime.now().withNano(0);
         }
     }
-    public void setUpdatedAt(){
+
+    public void setUpdatedAt() {
         updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/skillup/global/common/CommonMapper.java
+++ b/src/main/java/com/example/skillup/global/common/CommonMapper.java
@@ -7,6 +7,9 @@ import java.time.format.DateTimeFormatter;
 import org.springframework.data.domain.Pageable;
 
 public class CommonMapper {
+
+    private static final int MAX_REASON_LENGTH = 1000;
+
     public static String toDatePattern(LocalDateTime dateTime) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
         return dateTime.format(formatter);
@@ -31,7 +34,26 @@ public class CommonMapper {
     }
 
     public static BigDecimal toBigDecimal(Double value) {
-        if (value == null) return null;
+        if (value == null) {
+            return null;
+        }
         return BigDecimal.valueOf(value).setScale(7, RoundingMode.HALF_UP);
+    }
+
+    public static String normalizeReason(Exception e, String prefixMessage) {
+
+        String result;
+
+        if (e == null || e.getMessage() == null || e.getMessage().isBlank()) {
+            result = prefixMessage + ": 알 수 없는 오류";
+        } else if (prefixMessage == null || prefixMessage.isBlank()) {
+            result = e.getMessage();
+        } else {
+            result = prefixMessage + ": " + e.getMessage();
+        }
+
+        return result.length() > MAX_REASON_LENGTH
+                ? result.substring(0, MAX_REASON_LENGTH)
+                : result;
     }
 }

--- a/src/main/java/com/example/skillup/global/recovery/entity/FileCleanupFailure.java
+++ b/src/main/java/com/example/skillup/global/recovery/entity/FileCleanupFailure.java
@@ -1,0 +1,68 @@
+package com.example.skillup.global.recovery.entity;
+
+import com.example.skillup.global.recovery.enums.ResourceType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "file_cleanup_failure")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FileCleanupFailure extends RetryFailureBase {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private ResourceType resourceType;
+
+    @Column
+    private Long resourceId; // 해당 DB 에서 저장되어있는 ID
+
+    @Column(length = 500)
+    private String fileUrl;
+
+    @Column(length = 255)
+    private String bucket;
+
+    @Column(length = 500)
+    private String objectKey;
+
+    private FileCleanupFailure(
+            ResourceType resourceType,
+            Long resourceId,
+            String fileUrl,
+            String bucket,
+            String objectKey,
+            String failureReason
+    ) {
+        this.resourceType = resourceType;
+        this.resourceId = resourceId;
+        this.fileUrl = fileUrl;
+        this.bucket = bucket;
+        this.objectKey = objectKey;
+        initFailure(failureReason);
+    }
+
+    public static FileCleanupFailure of(
+            ResourceType resourceType,
+            Long resourceId,
+            String fileUrl,
+            String bucket,
+            String objectKey,
+            String failureReason
+    ) {
+        return new FileCleanupFailure(
+                resourceType,
+                resourceId,
+                fileUrl,
+                bucket,
+                objectKey,
+                failureReason
+        );
+    }
+}

--- a/src/main/java/com/example/skillup/global/recovery/entity/RetryFailureBase.java
+++ b/src/main/java/com/example/skillup/global/recovery/entity/RetryFailureBase.java
@@ -1,0 +1,70 @@
+package com.example.skillup.global.recovery.entity;
+
+import com.example.skillup.global.recovery.enums.RetryStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class RetryFailureBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private RetryStatus status = RetryStatus.PENDING;
+
+    @Column(nullable = false)
+    private int retryCount = 0;
+
+    @Column(nullable = false, length = 1000)
+    private String failureReason;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastTriedAt;
+
+    private LocalDateTime processedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    protected void initFailure(String failureReason) {
+        this.status = RetryStatus.PENDING;
+        this.retryCount = 1;
+        this.failureReason = failureReason;
+        this.lastTriedAt = LocalDateTime.now();
+    }
+
+    public void markSuccess() {
+        this.status = RetryStatus.SUCCEEDED;
+        this.processedAt = LocalDateTime.now();
+    }
+
+    public void increaseRetryCount(String failureReason) {
+        this.retryCount++;
+        this.failureReason = failureReason;
+        this.lastTriedAt = LocalDateTime.now();
+    }
+
+    public void markFailed() {
+        this.status = RetryStatus.FAILED;
+        this.lastTriedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/skillup/global/recovery/entity/SearchIndexFailure.java
+++ b/src/main/java/com/example/skillup/global/recovery/entity/SearchIndexFailure.java
@@ -1,0 +1,61 @@
+package com.example.skillup.global.recovery.entity;
+
+import com.example.skillup.global.recovery.enums.ResourceType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "search_index_failure")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchIndexFailure extends RetryFailureBase {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private ResourceType resourceType;
+
+    @Column(nullable = false)
+    private Long resourceId;
+
+    @Column(nullable = false, length = 100)
+    private String indexName;
+
+    @Column(nullable = false, length = 100)
+    private String documentId;
+
+    private SearchIndexFailure(
+            ResourceType resourceType,
+            Long resourceId,
+            String indexName,
+            String documentId,
+            String failureReason
+    ) {
+        this.resourceType = resourceType;
+        this.resourceId = resourceId;
+        this.indexName = indexName;
+        this.documentId = documentId;
+        initFailure(failureReason);
+    }
+
+    public static SearchIndexFailure of(
+            ResourceType resourceType,
+            Long resourceId,
+            String indexName,
+            String documentId,
+            String failureReason
+    ) {
+        return new SearchIndexFailure(
+                resourceType,
+                resourceId,
+                indexName,
+                documentId,
+                failureReason
+        );
+    }
+}

--- a/src/main/java/com/example/skillup/global/recovery/enums/ResourceType.java
+++ b/src/main/java/com/example/skillup/global/recovery/enums/ResourceType.java
@@ -1,0 +1,5 @@
+package com.example.skillup.global.recovery.enums;
+
+public enum ResourceType {
+    EVENT , ARTICLE , USER_PROFILE , BANNER
+}

--- a/src/main/java/com/example/skillup/global/recovery/enums/RetryStatus.java
+++ b/src/main/java/com/example/skillup/global/recovery/enums/RetryStatus.java
@@ -1,0 +1,5 @@
+package com.example.skillup.global.recovery.enums;
+
+public enum RetryStatus {
+    PENDING, SUCCEEDED, FAILED
+}

--- a/src/main/java/com/example/skillup/global/recovery/repository/FileCleanupFailureRepository.java
+++ b/src/main/java/com/example/skillup/global/recovery/repository/FileCleanupFailureRepository.java
@@ -1,0 +1,10 @@
+package com.example.skillup.global.recovery.repository;
+
+import com.example.skillup.global.recovery.entity.FileCleanupFailure;
+import com.example.skillup.global.recovery.enums.RetryStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileCleanupFailureRepository extends JpaRepository<FileCleanupFailure, Long> {
+    List<FileCleanupFailure> findTop100ByStatusOrderByCreatedAtAsc(RetryStatus status);
+}

--- a/src/main/java/com/example/skillup/global/recovery/repository/SearchIndexFailureRepository.java
+++ b/src/main/java/com/example/skillup/global/recovery/repository/SearchIndexFailureRepository.java
@@ -1,0 +1,10 @@
+package com.example.skillup.global.recovery.repository;
+
+import com.example.skillup.global.recovery.entity.SearchIndexFailure;
+import com.example.skillup.global.recovery.enums.RetryStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SearchIndexFailureRepository extends JpaRepository<SearchIndexFailure, Long> {
+    List<SearchIndexFailure> findTop100ByStatusOrderByCreatedAtAsc(RetryStatus status);
+}

--- a/src/main/java/com/example/skillup/global/recovery/service/FileCleanupFailureSaveService.java
+++ b/src/main/java/com/example/skillup/global/recovery/service/FileCleanupFailureSaveService.java
@@ -1,0 +1,34 @@
+package com.example.skillup.global.recovery.service;
+
+import com.example.skillup.global.recovery.entity.FileCleanupFailure;
+import com.example.skillup.global.recovery.enums.ResourceType;
+import com.example.skillup.global.recovery.repository.FileCleanupFailureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FileCleanupFailureSaveService {
+    private final FileCleanupFailureRepository fileCleanupFailureRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFailure(ResourceType resourceType,
+                            Long resourceId,
+                            String fileUrl,
+                            String bucket,
+                            String objectKey,
+                            String failureReason
+    ) {
+        FileCleanupFailure failure = FileCleanupFailure.of(
+                resourceType,
+                resourceId,
+                fileUrl,
+                bucket,
+                objectKey,
+                failureReason
+        );
+        fileCleanupFailureRepository.save(failure);
+    }
+}

--- a/src/main/java/com/example/skillup/global/recovery/service/FileCleanupRetryService.java
+++ b/src/main/java/com/example/skillup/global/recovery/service/FileCleanupRetryService.java
@@ -1,0 +1,50 @@
+package com.example.skillup.global.recovery.service;
+
+import com.example.skillup.global.common.CommonMapper;
+import com.example.skillup.global.recovery.entity.FileCleanupFailure;
+import com.example.skillup.global.recovery.enums.RetryStatus;
+import com.example.skillup.global.recovery.repository.FileCleanupFailureRepository;
+import com.example.skillup.global.service.S3Service;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FileCleanupRetryService {
+    private static final int MAX_RETRY_COUNT = 3;
+
+    private final FileCleanupFailureRepository fileCleanupFailureRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public void retryPendingFailures() {
+        List<FileCleanupFailure> failures = fileCleanupFailureRepository.findTop100ByStatusOrderByCreatedAtAsc(
+                RetryStatus.PENDING);
+
+        for (FileCleanupFailure failure : failures) {
+            if (failure.getRetryCount() >= MAX_RETRY_COUNT) {
+                failure.markFailed();
+                continue;
+            }
+
+            try {
+
+                if (failure.getFileUrl() == null || failure.getFileUrl().isBlank()) {
+                    throw new IllegalArgumentException("삭제할 Url이 없습니다.");
+                }
+
+                s3Service.deleteFileFromUrl(failure.getFileUrl());
+                failure.markSuccess();
+
+            } catch (Exception e) {
+                log.error("S3 파일 재처리 실패 - failureId={}", failure.getId(), e);
+                String reason = CommonMapper.normalizeReason(e , "S3 파일 재처리 실패");
+                failure.increaseRetryCount(reason);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/skillup/global/recovery/service/SearchIndexFailureSaveService.java
+++ b/src/main/java/com/example/skillup/global/recovery/service/SearchIndexFailureSaveService.java
@@ -1,0 +1,35 @@
+package com.example.skillup.global.recovery.service;
+
+import com.example.skillup.global.recovery.entity.SearchIndexFailure;
+import com.example.skillup.global.recovery.enums.ResourceType;
+import com.example.skillup.global.recovery.repository.SearchIndexFailureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SearchIndexFailureSaveService {
+
+    private final SearchIndexFailureRepository searchIndexFailureRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFailure(
+            ResourceType resourceType,
+            Long resourceId,
+            String indexName,
+            String documentId,
+            String failureReason
+    ) {
+        SearchIndexFailure failure = SearchIndexFailure.of(
+                resourceType,
+                resourceId,
+                indexName,
+                documentId,
+                failureReason
+        );
+
+        searchIndexFailureRepository.save(failure);
+    }
+}

--- a/src/main/java/com/example/skillup/global/recovery/service/SearchIndexRetryService.java
+++ b/src/main/java/com/example/skillup/global/recovery/service/SearchIndexRetryService.java
@@ -1,0 +1,64 @@
+package com.example.skillup.global.recovery.service;
+
+import com.example.skillup.domain.event.entity.Event;
+import com.example.skillup.domain.event.repository.EventRepository;
+import com.example.skillup.global.common.CommonMapper;
+import com.example.skillup.global.recovery.entity.SearchIndexFailure;
+import com.example.skillup.global.recovery.enums.ResourceType;
+import com.example.skillup.global.recovery.enums.RetryStatus;
+import com.example.skillup.global.recovery.repository.SearchIndexFailureRepository;
+import com.example.skillup.global.search.service.EventIndexerService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SearchIndexRetryService {
+    private static final int MAX_RETRY_COUNT = 3;
+
+    private final SearchIndexFailureRepository searchIndexFailureRepository;
+    private final EventRepository eventRepository;
+    private final EventIndexerService eventIndexerService;
+
+    @Transactional
+    public void retryPendingFailures() {
+        List<SearchIndexFailure> failures =
+                searchIndexFailureRepository.findTop100ByStatusOrderByCreatedAtAsc(RetryStatus.PENDING);
+
+        for (SearchIndexFailure failure : failures) {
+            if (failure.getRetryCount() >= MAX_RETRY_COUNT) {
+                failure.markFailed();
+                continue;
+            }
+
+            try {
+                retry(failure);
+                failure.markSuccess();
+
+            } catch (Exception e) {
+                log.error("검색 인덱스 재처리 실패 - failureId={}", failure.getId(), e);
+
+                String reason = CommonMapper.normalizeReason(e, "검색 인덱스 재처리 실패");
+                failure.increaseRetryCount(reason);
+
+                if (failure.getRetryCount() >= MAX_RETRY_COUNT) {
+                    failure.markFailed();
+                }
+            }
+        }
+    }
+
+    private void retry(SearchIndexFailure failure) {
+        if (failure.getResourceType() == ResourceType.EVENT) {
+            Event event = eventRepository.getEvent(failure.getResourceId());
+            eventIndexerService.index(event);
+            return;
+        }
+
+        throw new IllegalArgumentException("지원하지 않는 ResourceType 입니다. resourceType=" + failure.getResourceType());
+    }
+}

--- a/src/main/java/com/example/skillup/global/scheduler/FileCleanupRetryScheduler.java
+++ b/src/main/java/com/example/skillup/global/scheduler/FileCleanupRetryScheduler.java
@@ -1,0 +1,21 @@
+package com.example.skillup.global.scheduler;
+
+import com.example.skillup.global.recovery.service.FileCleanupRetryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FileCleanupRetryScheduler {
+
+    private final FileCleanupRetryService fileCleanupRetryService;
+
+    @Scheduled(cron = "0 0 5 * * *")
+    public void retryFileCleanupFailures() {
+        log.info("S3 파일 정리 실패 재처리 스케줄러 실행");
+        fileCleanupRetryService.retryPendingFailures();
+    }
+}

--- a/src/main/java/com/example/skillup/global/scheduler/SearchIndexRetryScheduler.java
+++ b/src/main/java/com/example/skillup/global/scheduler/SearchIndexRetryScheduler.java
@@ -1,0 +1,21 @@
+package com.example.skillup.global.scheduler;
+
+import com.example.skillup.global.recovery.service.SearchIndexRetryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SearchIndexRetryScheduler {
+
+    private final SearchIndexRetryService searchIndexRetryService;
+
+    @Scheduled(fixedDelay = 900000) // 15분 주기
+    public void retrySearchIndexFailures() {
+        log.info("검색 인덱스 실패 재처리 스케줄러 실행");
+        searchIndexRetryService.retryPendingFailures();
+    }
+}

--- a/src/test/java/com/example/skillup/global/recovery/RecoveryFlowIntegrationTest.java
+++ b/src/test/java/com/example/skillup/global/recovery/RecoveryFlowIntegrationTest.java
@@ -1,0 +1,212 @@
+package com.example.skillup.global.recovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.example.skillup.domain.event.entity.Event;
+import com.example.skillup.domain.event.events.EventCreatedEvent;
+import com.example.skillup.domain.event.events.ThumbnailUploadedEvent;
+import com.example.skillup.domain.event.repository.EventRepository;
+import com.example.skillup.global.recovery.entity.FileCleanupFailure;
+import com.example.skillup.global.recovery.entity.SearchIndexFailure;
+import com.example.skillup.global.recovery.enums.ResourceType;
+import com.example.skillup.global.recovery.enums.RetryStatus;
+import com.example.skillup.global.recovery.repository.FileCleanupFailureRepository;
+import com.example.skillup.global.recovery.repository.SearchIndexFailureRepository;
+import com.example.skillup.global.recovery.service.FileCleanupRetryService;
+import com.example.skillup.global.recovery.service.SearchIndexRetryService;
+import com.example.skillup.global.search.service.EventIndexerService;
+import com.example.skillup.global.service.S3Service;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class RecoveryFlowIntegrationTest {
+
+    @MockitoBean
+    private S3Service s3Service;
+    @MockitoBean
+    private EventRepository eventRepository;
+    @MockitoBean
+    private EventIndexerService eventIndexerService;
+
+    static class TestTxPublisher {
+
+        private final ApplicationEventPublisher eventPublisher;
+
+        public TestTxPublisher(ApplicationEventPublisher eventPublisher) {
+            this.eventPublisher = eventPublisher;
+        }
+
+        @Transactional
+        public void publishEventCreatedAfterCommit(Long eventId) {
+            eventPublisher.publishEvent(new EventCreatedEvent(eventId));
+        }
+
+        @Transactional
+        public void publishThumbnailUploadedAndRollback(String thumbnailUrl) {
+            eventPublisher.publishEvent(new ThumbnailUploadedEvent(ResourceType.EVENT, thumbnailUrl));
+            throw new RuntimeException("강제 롤백");
+        }
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        TestTxPublisher testTxPublisher(ApplicationEventPublisher eventPublisher) {
+            return new TestTxPublisher(eventPublisher);
+        }
+    }
+
+    @Autowired
+    private TestTxPublisher testTxPublisher;
+
+    @Autowired
+    private FileCleanupFailureRepository fileCleanupFailureRepository;
+
+    @Autowired
+    private SearchIndexFailureRepository searchIndexFailureRepository;
+
+    @Autowired
+    private FileCleanupRetryService fileCleanupRetryService;
+
+    @Autowired
+    private SearchIndexRetryService searchIndexRetryService;
+
+    @AfterEach
+    void tearDown() {
+        fileCleanupFailureRepository.deleteAllInBatch();
+        searchIndexFailureRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("AFTER_COMMIT 인덱싱 실패 시 search_index_failure 테이블에 저장된다")
+    void afterCommit_indexingFail_saveSearchIndexFailure() {
+        // given
+        Long eventId = 1L;
+        Event mockEvent = Mockito.mock(Event.class);
+
+        when(eventRepository.getEvent(eventId)).thenReturn(mockEvent);
+        doThrow(new RuntimeException("ES 연결 실패"))
+                .when(eventIndexerService).index(mockEvent);
+
+        // when
+        testTxPublisher.publishEventCreatedAfterCommit(eventId);
+
+        // then
+        List<SearchIndexFailure> failures = searchIndexFailureRepository.findAll();
+        assertThat(failures).hasSize(1);
+
+        SearchIndexFailure failure = failures.get(0);
+        assertThat(failure.getStatus()).isEqualTo(RetryStatus.PENDING);
+        assertThat(failure.getRetryCount()).isEqualTo(1);
+        assertThat(failure.getResourceType()).isEqualTo(ResourceType.EVENT);
+        assertThat(failure.getResourceId()).isEqualTo(eventId);
+        assertThat(failure.getIndexName()).isEqualTo("events_v3");
+        assertThat(failure.getDocumentId()).isEqualTo(String.valueOf(eventId));
+        assertThat(failure.getFailureReason()).contains("Elastic Search 인덱싱 실패: ES 연결 실패");
+    }
+
+    @Test
+    @DisplayName("AFTER_ROLLBACK 썸네일 삭제 실패 시 file_cleanup_failure 테이블에 저장된다")
+    void afterRollback_thumbnailDeleteFail_saveFileCleanupFailure() {
+        // given
+        String thumbnailUrl = "https://test-bucket.s3.ap-northeast-2.amazonaws.com/event/thumb/a.png";
+
+        doThrow(new RuntimeException("S3 삭제 실패"))
+                .when(s3Service).deleteFileFromUrl(thumbnailUrl);
+
+        // when
+        assertThatThrownBy(() -> testTxPublisher.publishThumbnailUploadedAndRollback(thumbnailUrl))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("강제 롤백");
+
+        // then
+        List<FileCleanupFailure> failures = fileCleanupFailureRepository.findAll();
+        assertThat(failures).hasSize(1);
+
+        FileCleanupFailure failure = failures.get(0);
+        assertThat(failure.getStatus()).isEqualTo(RetryStatus.PENDING);
+        assertThat(failure.getRetryCount()).isEqualTo(1);
+        assertThat(failure.getFileUrl()).isEqualTo(thumbnailUrl);
+        assertThat(failure.getResourceType()).isEqualTo(ResourceType.EVENT);
+        assertThat(failure.getResourceId()).isNull();
+        assertThat(failure.getFailureReason()).contains("S3 이미지 롤백 실패");
+        assertThat(failure.getFailureReason()).contains("S3 삭제 실패");
+    }
+
+    @Test
+    @DisplayName("파일 정리 재처리 성공 시 SUCCESS 상태로 변경된다")
+    void fileCleanupRetry_success_markSuccess() {
+        // given
+        String thumbnailUrl = "https://test-bucket.s3.ap-northeast-2.amazonaws.com/event/thumb/b.png";
+
+        FileCleanupFailure failure = FileCleanupFailure.of(
+                ResourceType.EVENT,
+                null,
+                thumbnailUrl,
+                null,
+                null,
+                "초기 실패"
+        );
+        fileCleanupFailureRepository.save(failure);
+
+        doNothing().when(s3Service).deleteFileFromUrl(thumbnailUrl);
+
+        // when
+        fileCleanupRetryService.retryPendingFailures();
+
+        // then
+        FileCleanupFailure saved = fileCleanupFailureRepository.findAll().get(0);
+        assertThat(saved.getStatus()).isEqualTo(RetryStatus.SUCCEEDED);
+        assertThat(saved.getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("검색 인덱스 재처리 반복 실패 시 FAILED 상태로 변경된다")
+    void searchIndexRetry_failUntilMax_markFailed() {
+        // given
+        Long eventId = 10L;
+        Event mockEvent = Mockito.mock(Event.class);
+
+        SearchIndexFailure failure = SearchIndexFailure.of(
+                ResourceType.EVENT,
+                eventId,
+                "events_v3",
+                String.valueOf(eventId),
+                "최초 실패"
+        );
+        failure.increaseRetryCount("두 번째 실패");
+        searchIndexFailureRepository.save(failure);
+
+        when(eventRepository.getEvent(eventId)).thenReturn(mockEvent);
+        doThrow(new RuntimeException("재시도도 실패"))
+                .when(eventIndexerService).index(any(Event.class));
+
+        // when
+        searchIndexRetryService.retryPendingFailures();
+
+        // then
+        SearchIndexFailure saved = searchIndexFailureRepository.findAll().get(0);
+        assertThat(saved.getRetryCount()).isEqualTo(3);
+        assertThat(saved.getStatus()).isEqualTo(RetryStatus.FAILED);
+        assertThat(saved.getFailureReason()).contains("검색 인덱스 재처리 실패");
+        assertThat(saved.getFailureReason()).contains("재시도도 실패");
+        assertThat(saved.getProcessedAt()).isNull();
+        assertThat(saved.getLastTriedAt()).isNotNull();
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

행사 생성/임시저장/발행/수정 과정에서 S3 업로드와 Elasticsearch 인덱싱이 DB 트랜잭션과 분리되지 않은 채 서비스 로직 안에서 직접 수행되고 있었습니다.

이로 인해 다음과 같은 정합성 문제가 발생할 수 있었습니다.

- DB 트랜잭션이 롤백되더라도 S3에는 업로드된 파일이 남는 문제(제목 일치 , DB 사이즈 오버시 등등)
- DB 트랜잭션이 롤백되더라도 Elasticsearch에는 문서가 반영되는 문제

이를 해결하기 위해 트랜잭션 결과에 따라 외부 자원 후처리가 수행되도록 이벤트 기반 구조로 변경했습니다.

추가로 유저 재가입시 deletd_at 가 null 로 변경 및 withdrawReason 이 null 로 초기화 되지 않는 부분이 있어서 수정했습니다.

---

## 주요 변경 사항

### 1. 트랜잭션 이벤트/리스너 추가
- `ThumbnailUploadedEvent`
  - 새 썸네일 업로드 후 발행
  - `AFTER_ROLLBACK`에서 업로드된 썸네일 삭제

- `ThumbnailReplacedEvent`
  - 기존 썸네일 교체 시 발행
  - `AFTER_COMMIT`에서 이전 썸네일 삭제

- `EventCreatedEvent`
  - 행사 저장 후 발행
  - `AFTER_COMMIT`에서 Elasticsearch 인덱싱 수행

### 2. 행사 생성 흐름 변경
- `createEvent`에서 썸네일 업로드 후 `ThumbnailUploadedEvent` 발행
- 행사 저장 후 `EventCreatedEvent` 발행
- 서비스 레이어에서 직접 수행하던 Elasticsearch 인덱싱 제거

### 3. 임시저장/발행/수정 흐름 변경
- `createDraftEvent`, `publishDraftEvent`, `updateEvent`에서 썸네일 교체를 검증 이후 수행하도록 변경
- 새 썸네일 업로드 시 롤백 후 삭제 이벤트 발행
- 기존 썸네일은 커밋 후 삭제 이벤트 발행
- 직접 수행하던 Elasticsearch 인덱싱을 제거하고 커밋 이후 리스너에서 처리하도록 변경


--- 

## 추가 전 
<img width="1406" height="458" alt="스크린샷 2026-03-28 오후 9 20 47" src="https://github.com/user-attachments/assets/13536b99-e96d-4067-a545-30692dc8d8ab" />

<img width="1154" height="82" alt="스크린샷 2026-03-28 오후 9 20 59" src="https://github.com/user-attachments/assets/f4e3d689-ca15-4867-8dc2-fde6e8d11004" />

aws s3 에 올라가고 DB 에는 저장되지 않는 문제 발생

## 추가 후 TEST
<img width="776" height="209" alt="스크린샷 2026-03-28 오후 10 30 14" src="https://github.com/user-attachments/assets/0b7f9bc6-1950-4082-8072-f3777158329e" />

의도적으로 error 발생시킨 후

<img width="1327" height="487" alt="스크린샷 2026-03-28 오후 10 30 30" src="https://github.com/user-attachments/assets/8660154d-2d5b-44f1-880c-aeefc3ab992d" />
<img width="1322" height="82" alt="스크린샷 2026-03-28 오후 10 34 56" src="https://github.com/user-attachments/assets/826f741f-0b60-4c80-ade0-e10c15c5579d" />

S3 및 ES 확인 


---
# 추가 변경사항 

리뷰 의견을 반영하여 트랜잭션 이후 실행되는 후속 작업의 실패가 묻히지 않도록, 실패 이력 저장 및 재처리 구조를 추가했습니다.

## 반영한 내용
- `AFTER_COMMIT` Elasticsearch 인덱싱 실패 시 `search_index_failure` 테이블에 실패 이력을 저장하도록 수정
- `AFTER_ROLLBACK` S3 이미지 삭제 실패 시 `file_cleanup_failure` 테이블에 실패 이력을 저장하도록 수정
- `AFTER_COMMIT` S3 기존 이미지 삭제 실패 시 `file_cleanup_failure` 테이블에 실패 이력을 저장하도록 수정
- 실패 이력 저장은 `REQUIRES_NEW` 트랜잭션으로 분리하여 원 트랜잭션과 별개로 기록되도록 구성
- 실패 건은 `PENDING / SUCCEEDED / FAILED` 상태와 `retryCount`로 관리하도록 구성
- 스케줄러를 통해 실패 이력을 재처리할 수 있도록 `FileCleanupRetryService`, `SearchIndexRetryService`를 추가

### 참고
현재 S3 삭제 재처리는 기존 구조를 유지하여 `fileUrl` 기반으로 처리하도록 구현했고, `bucket`, `objectKey`는 확장 가능성을 고려해 필드는 두되 현재는 `null`로 저장하도록 두었습니다.


## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
