### PR TITLE
[FIX] : 유저 북마크 조회 부분 수정

### DIFF
--- a/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
+++ b/src/main/java/com/example/skillup/domain/event/repository/EventBookmarkRepository.java
@@ -17,34 +17,13 @@ public interface EventBookmarkRepository extends JpaRepository<EventBookmark, Lo
     Optional<EventBookmark> findByUserAndEvent(Users user, Event event);
 
 
-
     @Query("""
-        select eb.event
-        from EventBookmark eb
-        where eb.user = :user and eb.isBookmarked = true
-        order by eb.createdAt desc
-       """)
-    Page<Event> findEventsByUserWithLatest(@Param("user") Users user,
-                                           Pageable pageable);
-
-
-    @Query("""
-        select eb.event
-        from EventBookmark eb
-        where eb.user = :user and eb.isBookmarked = true
-        order by eb.event.eventEnd asc
-       """)
-    Page<Event> findEventsByUserWithDeadLine(@Param("user") Users user,
-                              Pageable pageable);
-
-
-    @Query("""
-        select eb.event.id
-        from EventBookmark eb
-        where eb.user.id = :userId
-          and eb.event.id in :eventIds
-          and eb.isBookmarked = true
-    """)
+                select eb.event.id
+                from EventBookmark eb
+                where eb.user.id = :userId
+                  and eb.event.id in :eventIds
+                  and eb.isBookmarked = true
+            """)
     List<Long> findBookmarkedEventIds(@Param("userId") Long userId,
                                       @Param("eventIds") List<Long> eventIds);
 
@@ -53,23 +32,69 @@ public interface EventBookmarkRepository extends JpaRepository<EventBookmark, Lo
     void softDeleteAllByEventId(@Param("eventId") Long eventId);
 
     @Query(value = """
-    SELECT
-        CAST(eb.user_id AS CHAR) AS actorId,
-        eb.created_at            AS createdAt,
-        GROUP_CONCAT(tr.name ORDER BY tr.name SEPARATOR ',') AS targetRoles
-    FROM event_bookmark eb
-    JOIN event e
-        ON eb.event_id = e.id AND e.deleted_at IS NULL
-    JOIN event_target_role etr
-        ON e.id = etr.event_id
-    JOIN target_role tr
-        ON tr.id = etr.role_id
-    WHERE eb.created_at >= :since
-      AND eb.deleted_at IS NULL
-      AND eb.is_bookmarked = true
-    GROUP BY eb.id, eb.user_id, eb.created_at
-""", nativeQuery = true)
+                SELECT
+                    CAST(eb.user_id AS CHAR) AS actorId,
+                    eb.created_at            AS createdAt,
+                    GROUP_CONCAT(tr.name ORDER BY tr.name SEPARATOR ',') AS targetRoles
+                FROM event_bookmark eb
+                JOIN event e
+                    ON eb.event_id = e.id AND e.deleted_at IS NULL
+                JOIN event_target_role etr
+                    ON e.id = etr.event_id
+                JOIN target_role tr
+                    ON tr.id = etr.role_id
+                WHERE eb.created_at >= :since
+                  AND eb.deleted_at IS NULL
+                  AND eb.is_bookmarked = true
+                GROUP BY eb.id, eb.user_id, eb.created_at
+            """, nativeQuery = true)
     List<EventActionRepository.EventActionAnalyticsProjection> findBookmarkAnalyticsSince(
             @Param("since") LocalDateTime since
     );
+
+    @Query(value = """
+            select e
+            from EventBookmark eb
+            join eb.event e
+            where eb.user = :user
+              and eb.isBookmarked = true
+              and e.deletedAt is null
+              and e.eventEnd >= :now
+            """)
+    Page<Event> findRecruitingEventsByUser(Users user, LocalDateTime now, Pageable pageable);
+
+    @Query(value = """
+            select e
+            from EventBookmark eb
+            join eb.event e
+            where eb.user = :user
+              and eb.isBookmarked = true
+              and e.deletedAt is null
+              and e.eventEnd < :now
+            """)
+    Page<Event> findClosedEventsByUser(Users user, LocalDateTime now, Pageable pageable);
+
+    @Query("""
+            select count(e)
+            from EventBookmark eb
+            join eb.event e
+            where eb.user = :user
+              and eb.isBookmarked = true
+              and e.deletedAt is null
+              and e.eventEnd >= :now
+            """)
+    long countRecruitingEventsByUser(@Param("user") Users user,
+                                     @Param("now") LocalDateTime now);
+
+    @Query("""
+            select count(e)
+            from EventBookmark eb
+            join eb.event e
+            where eb.user = :user
+              and eb.isBookmarked = true
+              and e.deletedAt is null
+              and e.eventEnd < :now
+            """)
+    long countClosedEventsByUser(@Param("user") Users user,
+                                 @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/example/skillup/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/skillup/domain/user/controller/UserController.java
@@ -63,10 +63,12 @@ public class UserController {
                     description = "정렬 기준 (latest, deadline)"
             )
             @RequestParam String sort,
+            @Parameter(description = "조회 기준 (recruiting , closed)")
+            @RequestParam String status,
             @RequestParam int page
     ) {
         return BaseResponse.success("마이페이지 북마크된 이벤트 조회 성공",
-                userService.getMyPageBookMark(user.getUser(), sort, page));
+                userService.getMyPageBookMark(user.getUser(), sort, page , status));
     }
 
     @GetMapping("/my-page/profile/interest")

--- a/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/skillup/domain/user/dto/response/UserResponse.java
@@ -25,11 +25,13 @@ public class UserResponse {
     public static class MyPageBookMarkResponse {
         private String name;
         private String email;
-        List<EventResponse.HomeEventResponse> recruitingEvents;
-        List<EventResponse.HomeEventResponse> closedEvents;
         String role;
-        int bookmarkCount;
+        List<EventResponse.HomeEventResponse> events;
+        long closedCount;
+        long recruitingCount;
+        long bookmarkCount;
         CommonResponse.PageInfoResponse pageInfo;
+
     }
 
     @Getter

--- a/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
+++ b/src/main/java/com/example/skillup/domain/user/mappers/UserMapper.java
@@ -21,7 +21,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserMapper {
 
-    public static Users of(String email, String name, String socialId, SocialLoginType socialLoginType, String gender, String age, TargetRole role) {
+    public static Users of(String email, String name, String socialId, SocialLoginType socialLoginType, String gender,
+                           String age, TargetRole role) {
         return Users.builder()
                 .email(email)
                 .name(name)
@@ -48,8 +49,8 @@ public class UserMapper {
                                 ? oauthInfo.name()
                                 : "OAuthUser"
                 )
-                .age(oauthInfo.age()!=null ? oauthInfo.age() : "0")
-                .gender(oauthInfo.gender()!=null ? oauthInfo.gender() : "0")
+                .age(oauthInfo.age() != null ? oauthInfo.age() : "0")
+                .gender(oauthInfo.gender() != null ? oauthInfo.gender() : "0")
                 .socialId(oauthInfo.socialId())
                 .socialLoginType(oauthInfo.socialLoginType())
                 .status(UserStatus.ACTIVE)
@@ -69,15 +70,17 @@ public class UserMapper {
                 .build();
     }
 
-    public UserResponse.MyPageBookMarkResponse toMyPageBookMarkResponse(Users user, List<EventResponse.HomeEventResponse> recruitingEvents,
-                                                                        List<EventResponse.HomeEventResponse> closedEvents, CommonResponse.PageInfoResponse pageInfoResponse, long totalElements)
-    {
+    public UserResponse.MyPageBookMarkResponse toMyPageBookMarkResponse(Users user,
+                                                                        List<EventResponse.HomeEventResponse> eventResponseList,
+                                                                        CommonResponse.PageInfoResponse pageInfoResponse,
+                                                                        long recruitingCount, long closedCount) {
         return UserResponse.MyPageBookMarkResponse.builder()
-                .bookmarkCount((int) totalElements)
-                .recruitingEvents(recruitingEvents)
-                .closedEvents(closedEvents)
+                .events(eventResponseList)
                 .email(user.getEmail())
                 .name(user.getName())
+                .recruitingCount(recruitingCount)
+                .closedCount(closedCount)
+                .bookmarkCount(recruitingCount + closedCount)
                 .pageInfo(pageInfoResponse)
                 .role(user.getRole().getName())
                 .build();
@@ -110,8 +113,7 @@ public class UserMapper {
     }
 
     public UserResponse.WithDrawReasonCategoryResponse toWithDrawReasonCategoryResponse
-            (WithdrawReasonCategory withDrawReasonCategory)
-    {
+            (WithdrawReasonCategory withDrawReasonCategory) {
         return UserResponse.WithDrawReasonCategoryResponse.builder()
                 .description(withDrawReasonCategory.getDescription())
                 .build();
@@ -125,7 +127,7 @@ public class UserMapper {
                 .email(user.getEmail())
                 .socialLoginType(user.getSocialLoginType().getToKorean())
                 .role(CommonMapper.convertRole(user.getRole().getName()))
-                .status(user.getDeletedAt() != null? "탈퇴" : "활성").build();
+                .status(user.getDeletedAt() != null ? "탈퇴" : "활성").build();
     }
 
     public UserResponse.AdminUserDetailPageResponse toAdminUserDetailPageResponse(Users user) {
@@ -134,13 +136,14 @@ public class UserMapper {
                 .name(user.getName())
                 .createdAt(CommonMapper.toDatePattern(user.getCreatedAt()))
                 .email(user.getEmail())
-                .socialLoginType(user.getSocialLoginType().getToKorean()+" 로그인")
+                .socialLoginType(user.getSocialLoginType().getToKorean() + " 로그인")
                 .role(CommonMapper.convertRole(user.getRole().getName()))
                 .lastLoginAt(CommonMapper.toDatePattern(user.getLastLoginAt()))
-                .status(user.getDeletedAt() != null? "탈퇴" : "활성").build();
+                .status(user.getDeletedAt() != null ? "탈퇴" : "활성").build();
     }
 
-    public UserResponse.AdminUserEventActionCountsResponse toAdminUserEventActionResponse(int viewCount, int saveCount, int applyCount) {
+    public UserResponse.AdminUserEventActionCountsResponse toAdminUserEventActionResponse(int viewCount, int saveCount,
+                                                                                          int applyCount) {
         return UserResponse.AdminUserEventActionCountsResponse.builder()
                 .viewCount(viewCount)
                 .saveCount(saveCount)

--- a/src/main/java/com/example/skillup/domain/user/service/UserService.java
+++ b/src/main/java/com/example/skillup/domain/user/service/UserService.java
@@ -27,16 +27,17 @@ import com.example.skillup.global.aop.ConvertNotFound;
 import com.example.skillup.global.auth.dto.response.TokenResponse;
 import com.example.skillup.global.auth.service.AuthService;
 import com.example.skillup.global.common.CommonResponse;
+import com.example.skillup.global.exception.CommonErrorCode;
 import com.example.skillup.global.service.NotFoundGuardService;
 import com.example.skillup.global.service.S3Service;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -66,41 +67,59 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserResponse.MyPageBookMarkResponse getMyPageBookMark(Users user, String sort, int page) {
-        Pageable pageable = PageRequest.of(page, 9);
-        Page<Event> eventBookmarks = Page.empty(pageable);
+    public UserResponse.MyPageBookMarkResponse getMyPageBookMark(Users user, String sort, int page, String status) {
+
+        Pageable pageable = createBookmarkPageable(page, status, sort);
+        LocalDateTime now = LocalDateTime.now();
 
         //user를 영속성 컨텍스트로 만들기 위해서
         user = notFoundGuardService.getUsersNative(user.getId());
 
-        switch (sort) {
-            case "latest" -> eventBookmarks = eventBookmarkRepository.findEventsByUserWithLatest(user, pageable);
-            case "deadline" -> eventBookmarks = eventBookmarkRepository.findEventsByUserWithDeadLine(user, pageable);
-        }
-        LocalDateTime now = LocalDateTime.now();
+        Page<Event> eventBookmarks = switch (status) {
+            case "recruiting" -> eventBookmarkRepository.findRecruitingEventsByUser(user, now, pageable);
+            case "closed" -> eventBookmarkRepository.findClosedEventsByUser(user, now, pageable);
+            default -> throw new UserException(CommonErrorCode.INVALID_INPUT_VALUE, "유효하지 않은 status 값입니다.");
+        };
 
-        CommonResponse.PageInfoResponse pageInfoResponse = CommonResponse.PageInfoResponse
-                .builder()
-                .currentPage(page + 1)
+        List<EventResponse.HomeEventResponse> events = eventBookmarks.getContent().stream()
+                .map(event -> eventMapper.toFeaturedEvent(event, true, event.isRecommendedManual(), event.isAd(), null))
+                .toList();
+
+        long recruitingCount;
+        long closedCount;
+
+        if ("recruiting".equals(status)) {
+            recruitingCount = eventBookmarks.getTotalElements();
+            closedCount = eventBookmarkRepository.countClosedEventsByUser(user, now);
+        } else {
+            closedCount = eventBookmarks.getTotalElements();
+            recruitingCount = eventBookmarkRepository.countRecruitingEventsByUser(user, now);
+        }
+
+        CommonResponse.PageInfoResponse pageInfoResponse = CommonResponse.PageInfoResponse.builder()
+                .currentPage(eventBookmarks.getNumber() + 1)
                 .pageSize(eventBookmarks.getSize())
                 .totalPages(eventBookmarks.getTotalPages())
                 .build();
 
-        List<EventResponse.HomeEventResponse> recruitingEvents = new ArrayList<>();
-        List<EventResponse.HomeEventResponse> closedEvents = new ArrayList<>();
+        return userMapper.toMyPageBookMarkResponse(user, events, pageInfoResponse, recruitingCount, closedCount);
+    }
 
-        for (Event event : eventBookmarks.getContent()) {
-            EventResponse.HomeEventResponse dto =
-                    eventMapper.toFeaturedEvent(event, true, event.isRecommendedManual(), event.isAd(), null);
+    private Pageable createBookmarkPageable(int page, String status, String sort) {
+        if ("latest".equals(sort)) {
+            return PageRequest.of(page, 9, Sort.by(Sort.Direction.DESC, "createdAt"));
+        }
 
-            if (event.getEventEnd() != null && event.getEventEnd().isBefore(now)) {
-                closedEvents.add(dto);
-            } else {
-                recruitingEvents.add(dto);
+        if ("deadline".equals(sort)) {
+            if ("recruiting".equals(status)) {
+                return PageRequest.of(page, 9, Sort.by(Sort.Direction.ASC, "event.eventEnd"));
+            }
+            if ("closed".equals(status)) {
+                return PageRequest.of(page, 9, Sort.by(Sort.Direction.DESC, "event.eventEnd"));
             }
         }
-        return userMapper.toMyPageBookMarkResponse(user, recruitingEvents, closedEvents, pageInfoResponse,
-                eventBookmarks.getTotalElements());
+
+        throw new UserException(CommonErrorCode.INVALID_INPUT_VALUE, "유효하지 않은 sort 값입니다.");
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/example/skillup/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/skillup/domain/user/service/UserServiceTest.java
@@ -1,7 +1,7 @@
 package com.example.skillup.domain.user.service;
 
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -26,7 +26,6 @@ import com.example.skillup.domain.user.repository.UserRepository;
 import com.example.skillup.global.common.BaseEntity;
 import com.example.skillup.global.service.S3Service;
 import java.lang.reflect.Field;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,8 +67,10 @@ public class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        targetRoleRepository.deleteAll();
+        eventBookmarkRepository.deleteAll();
         userRepository.deleteAll();
+        targetRoleRepository.deleteAll();
+        eventRepository.deleteAll();
         role = targetRoleRepository.save(TargetRole.builder().name("PLANNER").build());
         targetRoleRepository.save(TargetRole.builder().name("DESIGNER").build());
         targetRoleRepository.save(TargetRole.builder().name("AI_DEVELOPER").build());
@@ -103,6 +104,7 @@ public class UserServiceTest {
 
         Field createdField = BaseEntity.class.getDeclaredField("createdAt");
         createdField.setAccessible(true);
+        LocalDateTime now = LocalDateTime.now();
 
         Event event1 = Event.builder()
                 .title("테스트 이벤트1")
@@ -125,7 +127,7 @@ public class UserServiceTest {
                 .recruitStart(LocalDateTime.now().minusDays(20))
                 .recruitEnd(LocalDateTime.now().plusDays(100))
                 .eventStart(LocalDateTime.now().minusDays(20))
-                .eventEnd(LocalDateTime.now().plusDays(20))
+                .eventEnd(LocalDateTime.now().plusDays(15))
                 .build();
 
         Event event3 = Event.builder()
@@ -149,35 +151,69 @@ public class UserServiceTest {
                 .recruitStart(LocalDateTime.now().minusDays(20))
                 .recruitEnd(LocalDateTime.now().plusDays(10))
                 .eventStart(LocalDateTime.now().minusDays(20))
-                .eventEnd(LocalDateTime.now().plusDays(200))
+                .eventEnd(LocalDateTime.now().plusDays(205))
                 .build();
 
         eventRepository.saveAll(List.of(event1, event2, event3, event4));
 
-        EventBookmark oldEventBookmark = EventBookmark.builder().event(event2).user(u1).build();
-        createdField.set(oldEventBookmark, LocalDate.now().minusMonths(5).atStartOfDay());
+        EventBookmark bookmark1 = EventBookmark.builder().event(event1).isBookmarked(true).user(u1).build();
+        EventBookmark bookmark2 = EventBookmark.builder().event(event2).isBookmarked(true).user(u1).build();
+        EventBookmark bookmark3 = EventBookmark.builder().event(event3).isBookmarked(true).user(u1).build();
+        EventBookmark bookmark4 = EventBookmark.builder().event(event4).isBookmarked(true).user(u1).build();
 
-        eventBookmarkRepository.save(oldEventBookmark);
+        createdField.set(bookmark1, now.minusDays(3));
+        createdField.set(bookmark2, now.minusMonths(5));
+        createdField.set(bookmark3, now.minusDays(2));
+        createdField.set(bookmark4, now.minusDays(1));
 
-        eventBookmarkRepository.save(EventBookmark.builder().event(event1).user(u1).build());
-        eventBookmarkRepository.save(EventBookmark.builder().event(event3).user(u1).build());
-        eventBookmarkRepository.save(EventBookmark.builder().event(event4).user(u1).build());
+        eventBookmarkRepository.saveAll(List.of(bookmark1, bookmark2, bookmark3, bookmark4));
 
-        UserResponse.MyPageBookMarkResponse response= userService.getMyPageBookMark(u1,"deadline",0);
+        // 1. closed + deadline
+        UserResponse.MyPageBookMarkResponse closedResponse =
+                userService.getMyPageBookMark(u1, "deadline", 0, "closed");
 
-        assertThat(u1.getEmail()).isEqualTo(response.getEmail());
-        assertThat(response.getPageInfo().getCurrentPage()).isEqualTo(1);
-        assertThat(response.getPageInfo().getTotalPages()).isEqualTo(1);
-        assertThat(response.getPageInfo().getPageSize()).isEqualTo(9);
-        assertThat(u1.getName()).isEqualTo(response.getName());
-        assertThat(event1.getId()).isEqualTo(response.getClosedEvents().get(0).getId());
-        assertThat(event4.getId()).isEqualTo(response.getRecruitingEvents().get(0).getId());
-        assertThat(1).isEqualTo(response.getClosedEvents().size());
-        assertThat(3).isEqualTo(response.getRecruitingEvents().size());
+        assertThat(closedResponse.getEmail()).isEqualTo(u1.getEmail());
+        assertThat(closedResponse.getName()).isEqualTo(u1.getName());
+        assertThat(closedResponse.getPageInfo().getCurrentPage()).isEqualTo(1);
+        assertThat(closedResponse.getPageInfo().getTotalPages()).isEqualTo(1);
+        assertThat(closedResponse.getPageInfo().getPageSize()).isEqualTo(9);
 
-        UserResponse.MyPageBookMarkResponse response2= userService.getMyPageBookMark(u1,"latest",0);
+        assertThat(closedResponse.getClosedCount()).isEqualTo(1);
+        assertThat(closedResponse.getRecruitingCount()).isEqualTo(3);
+        assertThat(closedResponse.getBookmarkCount()).isEqualTo(4);
 
-        assertThat(event2.getId()).isEqualTo(response2.getRecruitingEvents().get(2).getId());
+        assertThat(closedResponse.getEvents()).hasSize(1);
+        assertThat(closedResponse.getEvents().get(0).getId()).isEqualTo(event1.getId());
+
+        // 2. recruiting + deadline
+        UserResponse.MyPageBookMarkResponse recruitingDeadlineResponse =
+                userService.getMyPageBookMark(u1, "deadline", 0, "recruiting");
+
+        assertThat(recruitingDeadlineResponse.getClosedCount()).isEqualTo(1);
+        assertThat(recruitingDeadlineResponse.getRecruitingCount()).isEqualTo(3);
+        assertThat(recruitingDeadlineResponse.getBookmarkCount()).isEqualTo(4);
+
+        assertThat(recruitingDeadlineResponse.getPageInfo().getCurrentPage()).isEqualTo(1);
+        assertThat(recruitingDeadlineResponse.getPageInfo().getTotalPages()).isEqualTo(1);
+        assertThat(recruitingDeadlineResponse.getPageInfo().getPageSize()).isEqualTo(9);
+
+        assertThat(recruitingDeadlineResponse.getEvents()).hasSize(3);
+        assertThat(recruitingDeadlineResponse.getEvents().get(0).getId()).isEqualTo(event2.getId());
+        assertThat(recruitingDeadlineResponse.getEvents().get(1).getId()).isEqualTo(event3.getId());
+        assertThat(recruitingDeadlineResponse.getEvents().get(2).getId()).isEqualTo(event4.getId());
+
+        // 3. recruiting + latest
+        UserResponse.MyPageBookMarkResponse recruitingLatestResponse =
+                userService.getMyPageBookMark(u1, "latest", 0, "recruiting");
+
+        assertThat(recruitingLatestResponse.getClosedCount()).isEqualTo(1);
+        assertThat(recruitingLatestResponse.getRecruitingCount()).isEqualTo(3);
+        assertThat(recruitingLatestResponse.getBookmarkCount()).isEqualTo(4);
+
+        assertThat(recruitingLatestResponse.getEvents()).hasSize(3);
+        assertThat(recruitingLatestResponse.getEvents().get(0).getId()).isEqualTo(event4.getId());
+        assertThat(recruitingLatestResponse.getEvents().get(1).getId()).isEqualTo(event3.getId());
+        assertThat(recruitingLatestResponse.getEvents().get(2).getId()).isEqualTo(event2.getId());
 
 
     }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->

마이페이지 북마크 조회 로직을 상태별 조회 방식으로 수정했습니다

기존에는 북마크 목록을 한 번에 조회한 뒤 서비스 레이어에서 모집중/종료 상태를 나누고 있었는데,  
이 방식은 각 상태별 페이지 정보와 개수를 정확하게 계산하기 어렵다는 문제가 있었습니다.

이번 수정에서는 요청받은 `status` 값에 따라 필요한 북마크 목록만 조회하도록 변경하고,  
모집중/종료 개수는 별도로 계산해 함께 내려주도록 구조를 정리했습니다.

### 주요 변경 사항

- 북마크 조회 API에 `status` 파라미터를 반영하여 `recruiting` / `closed` 상태별 조회가 가능하도록 수정
- 서비스 레이어에서 전체 북마크를 조회 후 분류하던 방식 제거
- Repository에서 상태 조건에 맞는 북마크만 직접 조회하도록 쿼리 분리
- 응답 DTO를 현재 요청한 상태의 `events` 목록만 내려주는 구조로 변경
- 응답에 `closedCount`, `recruitingCount`, `bookmarkCount`, `pageInfo`를 함께 포함하도록 수정

## 테스트

- 북마크 상태별 조회(`recruiting`, `closed`)가 정상 동작하는지 확인
- `latest`, `deadline` 정렬 기준이 의도한 순서로 동작하는지 검증
- 응답 내 개수 정보(`closedCount`, `recruitingCount`, `bookmarkCount`)가 올바르게 반환되는지 확인

## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
